### PR TITLE
Encapsulate exec resources in classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ file { '/usr/lib/systemd/system/foo.service':
   mode   => '0644',
   source => "puppet:///modules/${module_name}/foo.service",
 } ~>
-Exec['systemctl-daemon-reload']
+Class['systemd::daemon_reload']
 ```
 
 ### systemd-tmpfiles --create
@@ -34,5 +34,5 @@ file { '/etc/tmpfiles.d/foo.conf':
   mode   => '0644',
   source => "puppet:///modules/${module_name}/foo.conf",
 } ~>
-Exec['systemd-tmpfiles-create']
+Class['systemd::tmpfiles_create']
 ```

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -1,0 +1,9 @@
+# -- Class: systemd::daemon_reload
+# Triggers systemd to reload unit files
+class systemd::daemon_reload {
+  exec { 'systemctl-daemon-reload':
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    path        => $::path,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,18 +1,6 @@
+# -- Class systemd
+# This module allows triggering systemd commands once for all modules
 class systemd {
-
-  Exec {
-    refreshonly => true,
-    path        => $::path,
-  }
-
-  exec {
-    'systemctl-daemon-reload':
-      command => 'systemctl daemon-reload',
-  }
-
-  exec {
-    'systemd-tmpfiles-create':
-      command => 'systemd-tmpfiles --create',
-  }
-
+  include ::systemd::daemon_reload
+  include ::systemd::tmpfiles_create
 }

--- a/manifests/tmpfiles_create.pp
+++ b/manifests/tmpfiles_create.pp
@@ -1,0 +1,9 @@
+# -- Class: systemd::tmpfiles_create
+# Triggers systemd to create tmpfiles
+class systemd::tmpfiles_create {
+  exec { 'systemd-tmpfiles-create':
+    command     => 'systemd-tmpfiles --create',
+    refreshonly => true,
+    path        => $::path,
+  }
+}


### PR DESCRIPTION
This allows us to maintain the commands or even handle them differently on different kinds of systemd installations.

This change is fully backward compatible.

refs #2
