### PR TITLE
Shortcut for creating unit files / tmpfiles

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,4 @@
+---
+fixtures:
+  symlinks:
+    systemd: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,23 @@
 
 ## Overview
 
-This module declares exec resources that you can use when you change systemd units or configuration files.
+This module declares exec resources to create global sync points for reloading systemd.
 
-## Examples
+## Usage and examples
 
-### systemctl --daemon-reload
+There are two ways to use this module.
+
+### unit files
+
+Let this module handle file creation and systemd reloading.
+
+```puppet
+::systemd::unit_file { 'foo.service':
+ source => "puppet:///modules/${module_name}/foo.service",
+}
+```
+
+Or handle file creation yourself and trigger systemd.
 
 ```puppet
 include ::systemd
@@ -23,7 +35,17 @@ file { '/usr/lib/systemd/system/foo.service':
 Exec['systemctl-daemon-reload']
 ```
 
-### systemd-tmpfiles --create
+### tmpfiles
+
+Let this module handle file creation and systemd reloading
+
+```puppet
+::systemd::tmpfile { 'foo.conf':
+  source => "puppet:///modules/${module_name}/foo.conf",
+}
+```
+
+Or handle file creation yourself and trigger systemd.
 
 ```puppet
 include ::systemd

--- a/manifests/tmpfile.pp
+++ b/manifests/tmpfile.pp
@@ -1,0 +1,20 @@
+# -- Define: systemd::tmpfile
+# Creates a tmpfile and reloads systemd
+define systemd::tmpfile(
+  $ensure = file,
+  $path = '/etc/tmpfiles.d',
+  $content = undef,
+  $source = undef,
+) {
+  include ::systemd
+
+  file { "${path}/${title}":
+    ensure  => $ensure,
+    content => $content,
+    source  => $source,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Exec['systemd-tmpfiles-create'],
+  }
+}

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -1,0 +1,20 @@
+# -- Define: systemd::unit_file
+# Creates a unit file and reloads systemd
+define systemd::unit_file(
+  $ensure = file,
+  $path = '/etc/systemd/system',
+  $content = undef,
+  $source = undef,
+) {
+  include ::systemd
+
+  file { "${path}/${title}":
+    ensure  => $ensure,
+    content => $content,
+    source  => $source,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Exec['systemctl-daemon-reload'],
+  }
+}

--- a/spec/defines/tmpfile_spec.rb
+++ b/spec/defines/tmpfile_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'systemd::tmpfile' do
+
+  let(:facts) { {
+      :path => '/usr/bin',
+  } }
+
+  context 'default params' do
+
+    let(:title) { 'fancy.conf' }
+
+    it 'creates the tmpfile' do
+      should contain_file('/etc/tmpfiles.d/fancy.conf').with({
+                                                                 'ensure' => 'file',
+                                                                 'owner' => 'root',
+                                                                 'group' => 'root',
+                                                                 'mode' => '0444',
+                                                             })
+    end
+
+    it 'triggers systemd daemon-reload' do
+      should contain_class('systemd')
+      should contain_file('/etc/tmpfiles.d/fancy.conf').with_notify("Exec[systemd-tmpfiles-create]")
+    end
+  end
+
+  context 'with params' do
+    let(:title) { 'fancy.conf' }
+
+    let(:params) { {
+        :ensure => 'absent',
+        :path => '/etc/tmpfiles.d/foo',
+        :content => 'some-content',
+        :source => 'some-source',
+    } }
+
+    it 'creates the unit file' do
+      should contain_file('/etc/tmpfiles.d/foo/fancy.conf').with({
+                                                                     'ensure' => 'absent',
+                                                                     'content' => 'some-content',
+                                                                     'source' => 'some-source',
+                                                                 })
+    end
+
+  end
+
+end

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'systemd::unit_file' do
+
+  let(:facts) { {
+      :path => '/usr/bin',
+  } }
+
+  context 'default params' do
+
+    let(:title) { 'fancy.service' }
+
+    it 'creates the unit file' do
+      should contain_file('/etc/systemd/system/fancy.service').with({
+                                                                        'ensure' => 'file',
+                                                                        'owner' => 'root',
+                                                                        'group' => 'root',
+                                                                        'mode' => '0444',
+                                                                    })
+    end
+
+    it 'triggers systemd daemon-reload' do
+      should contain_class('systemd')
+      should contain_file('/etc/systemd/system/fancy.service').with_notify("Exec[systemctl-daemon-reload]")
+    end
+  end
+
+  context 'with params' do
+    let(:title) { 'fancy.service' }
+
+    let(:params) { {
+        :ensure => 'absent',
+        :path => '/usr/lib/systemd/system',
+        :content => 'some-content',
+        :source => 'some-source',
+    } }
+
+    it 'creates the unit file' do
+      should contain_file('/usr/lib/systemd/system/fancy.service').with({
+                                                                            'ensure' => 'absent',
+                                                                            'content' => 'some-content',
+                                                                            'source' => 'some-source',
+                                                                        })
+    end
+
+  end
+
+end


### PR DESCRIPTION
This change allows creating unit files and reloading systemd with just a single resource.
It's fully compatible with the manual behavior.