### PR TITLE
only use awk, instead of grep and awk

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -30,6 +30,6 @@ end
 Facter.add(:systemd_version) do
   confine :systemd => true
   setcode do
-    Facter::Core::Execution.exec("systemctl --version | grep 'systemd' | awk '{ print $2 }'")
+    Facter::Core::Execution.exec("systemctl --version | awk '/systemd/{ print $2 }'")
   end
 end


### PR DESCRIPTION
This reduces a pipe, by only using `awk` for both of operations that of `grep`, and that of `awk`.