### PR TITLE
Refactor systemd facts

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -23,13 +23,13 @@
 Facter.add(:systemd) do
   confine :kernel => :linux
   setcode do
-    Facter::Core::Execution.exec('ps -p 1 -o comm=') == 'systemd'
+    Facter::Util::Resolution.exec('ps -p 1 -o comm=') == 'systemd'
   end
 end
 
 Facter.add(:systemd_version) do
   confine :systemd => true
   setcode do
-    Facter::Core::Execution.exec("systemctl --version | awk '/systemd/{ print $2 }'")
+    Facter::Util::Resolution.exec("systemctl --version | awk '/systemd/{ print $2 }'")
   end
 end

--- a/spec/unit/facter/systemd_spec.rb
+++ b/spec/unit/facter/systemd_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe "systemd" do
+    context 'returns true when systemd present' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns(:linux)
+      end
+      let(:facts) { {:kernel => :linux} }
+      it do
+        Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').returns('systemd')
+        expect(Facter.value(:systemd)).to eq(true)
+      end
+    end
+      context 'returns false when systemd not present' do
+        before do
+          Facter.fact(:kernel).stubs(:value).returns(:linux)
+        end
+        let(:facts) { {:kernel => :linux} }
+        it do
+          Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').returns('init')
+          expect(Facter.value(:systemd)).to eq(false)
+        end
+    end
+
+    context 'returns nil when kernel is not linux' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns(:windows)
+      end
+      let(:facts) { {:kernel => :windows} }
+      it do
+        Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').never
+        expect(Facter.value(:systemd)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/facter/systemd_version_spec.rb
+++ b/spec/unit/facter/systemd_version_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe "systemd_version" do
+    context 'returns version when systemd fact present' do
+      before do
+        Facter.fact(:systemd).stubs(:value).returns(true)
+      end
+      let(:facts) { {:systemd => true} }
+      it do
+        Facter::Util::Resolution.expects(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").returns('229')
+        expect(Facter.value(:systemd_version)).to eq('229')
+      end
+    end
+    context 'returns nil when systemd fact not present' do
+      before do
+        Facter.fact(:systemd).stubs(:value).returns(false)
+      end
+      let(:facts) { {:systemd => false } }
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").never
+        expect(Facter.value(:systemd_version)).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Use `Facter::Util::Resolution.exec`, which is backwards compatible with older Facter, calls the same method in modern facter
* Adds basic unit testing for facts