### PR TITLE
Manage resource limits of services

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,24 @@ file { '/etc/tmpfiles.d/foo.conf':
 } ~>
 Exec['systemd-tmpfiles-create']
 ```
+
+### service limits
+
+Manage soft and hard limits on various resources for executed processes.
+
+```puppet
+::systemd::service_limits { 'foo.service':
+  limits => {
+    LimitNOFILE => 8192,
+    LimitNPROC  => 16384
+  }
+}
+```
+
+Or provide the configuration file yourself. Systemd reloading and restarting of the service are handled by the module.
+
+```puppet
+::systemd::service_limits { 'foo.service':
+  source => "puppet:///modules/${module_name}/foo.conf",
+}
+```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,8 @@
-class systemd {
+# -- Class systemd  
+# This module allows triggering systemd commands once for all modules 
+class systemd (
+  $service_limits = {}
+){
 
   Exec {
     refreshonly => true,
@@ -14,5 +18,7 @@ class systemd {
     'systemd-tmpfiles-create':
       command => 'systemd-tmpfiles --create',
   }
+
+  create_resources('systemd::service_limits', $service_limits, {})
 
 }

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -1,0 +1,50 @@
+# -- Define: systemd::service_limits
+# Creates a custom config file and reloads systemd
+define systemd::service_limits(
+  $ensure          = file,
+  $path            = '/etc/systemd/system',
+  $limits          = undef,
+  $source          = undef,
+  $restart_service = true
+) {
+  include ::systemd
+
+  if $limits {
+    validate_hash($limits)
+    $content = template('systemd/limits.erb')
+  }
+  else {
+    $content = undef
+  }
+
+  if $limits and $source {
+    fail('You may not supply both limits and source parameters to systemd::service_limits')
+  } elsif $limits == undef and $source == undef {
+    fail('You must supply either the limits or source parameter to systemd::service_limits')
+  }
+
+  file { "${path}/${title}.d/":
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+  }
+  ->
+  file { "${path}/${title}.d/limits.conf":
+    ensure  => $ensure,
+    content => $content,
+    source  => $source,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Exec['systemctl-daemon-reload'],
+  }
+
+  if $restart_service {
+    exec { "systemctl restart ${title}":
+      path        => $::path,
+      refreshonly => true,
+      subscribe   => File["${path}/${title}.d/limits.conf"],
+      require     => Exec['systemctl-daemon-reload'],
+    }
+  }
+}

--- a/templates/limits.erb
+++ b/templates/limits.erb
@@ -1,0 +1,26 @@
+# This file is created by Puppet
+[Service]
+<%
+[
+  'LimitCPU',
+  'LimitFSIZE',
+  'LimitDATA',
+  'LimitSTACK',
+  'LimitCORE',
+  'LimitRSS',
+  'LimitNOFILE',
+  'LimitAS',
+  'LimitNPROC',
+  'LimitMEMLOCK',
+  'LimitLOCKS',
+  'LimitSIGPENDING',
+  'LimitMSGQUEUE',
+  'LimitNICE',
+  'LimitRTPRIO',
+  'LimitRTTIME'
+].each do |d|
+if @limits[d] -%>
+<%= d %>=<%= @limits[d] %>
+<%
+end
+end %>


### PR DESCRIPTION
Hi,

Are you planning to improve the module further or is the idea to keep it simple and use it as a "global sync points for reloading systemd"?

Here is a PR for managing resource limits for services started by systemd.  
The module creates _servicename.service_.d/limits.conf file for storing the extra configuration for the service, refreshes systemd and restarts the service.  
Limits are configurable also by using hiera.
