### PR TITLE
Specify settings for a new unit file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,4 +1,6 @@
 ---
 fixtures:
+  repositories:
+   "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:
     systemd: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ Let this module handle file creation and systemd reloading.
  source => "puppet:///modules/${module_name}/foo.service",
 }
 ```
+Or specify a settings hash for a new unit file.
+
+```puppet
+::systemd::unit_file{ 'foo.service':
+   settings => { 'Description'     => 'the foo service',
+                 'ExecStart'       => '/bin/foo',
+                 'Wants'           => ['network.target', 'bar.service'],
+                 'Type'            => 'oneshot',
+                 'EnvironmentFile' => ['-/etc/sysconfig/foo','/etc/sysconfig/myfoo'],
+               }
+}
+```
+The following keys for the settings hash are supported: `Description`, `Requires`, `Conflicts`, `Wants`,
+`After`, `Type`, `ExecStart`, `ExecStop`, `ExecReload`, `Environment`, `EnvironmentFile`, `WorkingDirectory`,
+`Restart`, `RestartSec`, `RestartAfterExec` and`WantedBy`. If a value is specified as an array multiple
+lines will be added to the unit file.
+
 
 Or handle file creation yourself and trigger systemd.
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -5,13 +5,30 @@ define systemd::unit_file(
   $path = '/etc/systemd/system',
   $content = undef,
   $source = undef,
+  $settings = undef,
   $target = undef,
 ) {
   include ::systemd
 
+  if $settings and $source {
+    fail('You may not supply both settings and source parameters to systemd::unit_file')
+  }
+  if $settings and $content {
+    fail('You may not supply both settings and content parameters to systemd::unit_file')
+  }
+
+  if $settings {
+    validate_hash($settings)
+    $_content = template('systemd/unit_file.erb')
+  } elsif $content {
+    $_content = $content
+  } else {
+    $_content = undef
+  }
+
   file { "${path}/${title}":
     ensure  => $ensure,
-    content => $content,
+    content => $_content,
     source  => $source,
     target  => $target,
     owner   => 'root',

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -47,4 +47,21 @@ describe 'systemd::unit_file' do
 
   end
 
+  context 'with settings' do
+    let(:title) { 'fancy.service' }
+
+    let(:params) { {
+        :ensure => 'absent',
+        :path => '/usr/lib/systemd/system',
+        :settings => {'EnvironmentFile' => ['','/etc/sysconfig/foo'],
+                      'Description' => 'Foo Service',
+                     }
+    } }
+    it 'creates the unit file' do
+      should contain_file('/usr/lib/systemd/system/fancy.service').with({
+                                                                            'ensure' => 'absent',
+                                                                            'content' => %r{^EnvironmentFile=$}
+                                                                        })
+    end
+  end
 end

--- a/templates/unit_file.erb
+++ b/templates/unit_file.erb
@@ -1,0 +1,85 @@
+#puppet managed file.
+
+[Unit]
+<%
+[
+  'Description',
+  'Requires',
+  'Conflicts',
+  'Wants',
+  'After',
+].each do |s| 
+if @settings[s]
+  if @settings[s].kind_of?(Array)
+    @settings[s].each do |v| 
+-%>
+<%= s %>=<%= v %>
+<%
+    end
+  elsif @settings[s].kind_of?(String) 
+-%>
+<%= s %>=<%= @settings[s] %>
+<%
+  else
+   raise Puppet::Error, "settings hash contains a key '#{s}' whose value which is not an array or a string"
+  end
+end
+end
+-%> 
+
+[Service]
+<%
+[
+  'Type',
+  'ExecStart',
+  'ExecStop',
+  'ExecReload',
+  'Environment',
+  'EnvironmentFile',
+  'WorkingDirectory',
+  'Restart',
+  'RestartSec',
+  'RestartAfterExec',
+].each do |s| 
+if @settings[s]
+  if @settings[s].kind_of?(Array)
+    @settings[s].each do |v| 
+-%>
+<%= s %>=<%= v %>
+<%
+    end
+  elsif @settings[s].kind_of?(String) 
+-%>
+<%= s %>=<%= @settings[s] %>
+<%
+  else
+   raise Puppet::Error, "settings hash contains a key '#{s}' whose value which is not an array or a string"
+  end
+end
+end
+-%> 
+
+[Install]
+<%
+[
+  'WantedBy',
+].each do |s| 
+if @settings[s]
+  if @settings[s].kind_of?(Array)
+    @settings[s].each do |v| 
+-%>
+<%= s %>=<%= v %>
+<%
+    end
+  elsif @settings[s].kind_of?(String) 
+-%>
+<%= s %>=<%= @settings[s] %>
+<%
+  else
+   raise Puppet::Error, "settings hash contains a key '#{s}' whose value which is not an array or a string"
+  end
+end
+end
+-%> 
+
+


### PR DESCRIPTION
Adds a new parameter `settings` to the
systemd::unit_file type.

```puppet
::systemd::unit_file{ 'foo.service':
   settings => { 'Description'     => 'the foo service',
                 'ExecStart'       => '/bin/foo',
                 'Wants'           => ['network.target', 'bar.service'],
                 'Type'            => 'oneshot',
                 'EnvironmentFile' => ['-/etc/sysconfig/foo','/etc/sysconfig/myfoo'],
               }
}
```

Allows a systemd file to be specified with a setting hash
rather than a source file.