### PR TITLE
Quote hash keys in example of service limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Manage soft and hard limits on various resources for executed processes.
 ```puppet
 ::systemd::service_limits { 'foo.service':
   limits => {
-    LimitNOFILE => 8192,
-    LimitNPROC  => 16384,
+    'LimitNOFILE' => 8192,
+    'LimitNPROC'  => 16384,
   }
 }
 ```


### PR DESCRIPTION
In Puppet 4, had to quote the hash keys in `limits` to make it work.  Otherwise it errors out:


```
     Puppet::PreformattedError:
       Evaluation Error: Resource type not found: LimitNOFILE at /home/stbenjam/git/puppet-qpid/spec/fixtures/modules/qpid/manifests/router/service.pp:17:9 on node zpm.bitbin.de
```
