### PR TITLE
Add MemoryLimit to limits template

### DIFF
--- a/templates/limits.erb
+++ b/templates/limits.erb
@@ -17,7 +17,8 @@
   'LimitMSGQUEUE',
   'LimitNICE',
   'LimitRTPRIO',
-  'LimitRTTIME'
+  'LimitRTTIME',
+  'MemoryLimit',
 ].each do |d|
 if @limits[d] -%>
 <%= d %>=<%= @limits[d] %>


### PR DESCRIPTION
MemoryLimit is required to restrict memory on a
systemd service effectvely. Its a more powerful
and working replacement to LimitRSS= which is
not implemented in linux. See man page[1] for
more details.

[1] http://www.dsm.fordham.edu/cgi-bin/man-cgi.pl?topic=systemd.exec&ampsect=5