### PR TITLE
Add seltype to systemd directory

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -24,9 +24,10 @@ define systemd::service_limits(
   }
 
   file { "${path}/${title}.d/":
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    seltype => 'systemd_unit_file_t',
   }
 
   -> file { "${path}/${title}.d/limits.conf":


### PR DESCRIPTION
The systemd service.d directory for service files apparently needs the seltype of `systemd_unit_file_t`

See also https://github.com/arioch/puppet-redis/pull/202

https://tickets.puppetlabs.com/browse/PUP-7559