### PR TITLE
Better test for systemd existence.

### DIFF
--- a/spec/unit/facter/systemd_spec.rb
+++ b/spec/unit/facter/systemd_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Util::Fact do
       end
       let(:facts) { {:kernel => :linux} }
       it do
-        Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').returns('systemd')
+        expect(Facter.value(:initsystem)).to eq(:systemd)
         expect(Facter.value(:systemd)).to eq(true)
       end
     end
@@ -22,7 +22,7 @@ describe Facter::Util::Fact do
         end
         let(:facts) { {:kernel => :linux} }
         it do
-          Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').returns('init')
+          expect(Facter.value(:initsystem)).not_to eq(:systemd)
           expect(Facter.value(:systemd)).to eq(false)
         end
     end
@@ -33,7 +33,7 @@ describe Facter::Util::Fact do
       end
       let(:facts) { {:kernel => :windows} }
       it do
-        Facter::Util::Resolution.expects(:exec).with('ps -p 1 -o comm=').never
+        expect(Facter.value(:initsystem)).to be_nil
         expect(Facter.value(:systemd)).to be_nil
       end
     end


### PR DESCRIPTION
As noted in #37 

Testing for the name of the init process fails on systems where init is always /sbin/init regardless of source package.

A better test is to check the output of `/proc/1/exe --version` for substrings.  This has the added benefit of distinguishing among non-systemd init systems.