### PR TITLE
Add support for drop-in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ file { '/usr/lib/systemd/system/foo.service':
 
 ### drop-in files
 
-Drop-in files are used to add or alter settings of a unit without modify the
-unit it self. As for the unit files, the module can handle the file and
+Drop-in files are used to add or alter settings of a unit without modifying the
+unit itself. As for the unit files, the module can handle the file and
 directory creation and systemd reloading:
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ file { '/usr/lib/systemd/system/foo.service':
 ~> Class['systemd::systemctl::daemon_reload']
 ```
 
+### drop-in files
+
+Drop-in files are used to add or alter settings of a unit without modify the
+unit it self. As for the unit files, the module can handle the file and
+directory creation and systemd reloading:
+
+```puppet
+::systemd::dropin_file { 'foo.conf':
+  unit   => 'foo.service',
+  source => "puppet:///modules/${module_name}/foo.conf",
+}
+```
+
+Or handle file and directory creation yourself and trigger systemd:
+
+```puppet
+include ::systemd::systemctl::daemon_reload
+
+file { '/etc/systemd/system/foo.service.d':
+  ensure => directory,
+  owner  => 'root',
+  group  => 'root',
+}
+file { '/etc/systemd/system/foo.service.d/foo.conf':
+  ensure => file,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0644',
+  source => "puppet:///modules/${module_name}/foo.conf",
+}
+~> Class['systemd::systemctl::daemon_reload']
+```
+
 ### tmpfiles
 
 Let this module handle file creation and systemd reloading

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -1,0 +1,69 @@
+# Creates a drop-in file for a systemd unit
+#
+# @api public
+#
+# @see systemd.unit(5)
+#
+# @attr name [Pattern['^.+\.conf$']]
+#   The target unit file to create
+#
+#   * Must not contain ``/``
+#
+# @attr path
+#   The main systemd configuration path
+#
+# @attr content
+#   The full content of the unit file
+#
+#   * Mutually exclusive with ``$source``
+#
+# @attr source
+#   The ``File`` resource compatible ``source``
+#
+#   * Mutually exclusive with ``$content``
+#
+# @attr target
+#   If set, will force the file to be a symlink to the given target
+#
+#   * Mutually exclusive with both ``$source`` and ``$content``
+#
+define systemd::dropin_file(
+  Systemd::Unit                     $unit,
+  Enum['present', 'absent', 'file'] $ensure  = 'present',
+  Stdlib::Absolutepath              $path    = '/etc/systemd/system',
+  Optional[String]                  $content = undef,
+  Optional[String]                  $source  = undef,
+  Optional[Stdlib::Absolutepath]    $target  = undef,
+) {
+  include ::systemd
+
+  assert_type(Systemd::Dropin, $name)
+
+  if $target {
+    $_ensure = 'link'
+  } else {
+    $_ensure = $ensure ? {
+      'present' => 'file',
+      default   => $ensure,
+    }
+  }
+
+  if $ensure != 'absent' {
+    ensure_resource('file', "${path}/${unit}.d", {
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+    })
+  }
+
+  file { "${path}/${unit}.d/${name}":
+    ensure  => $_ensure,
+    content => $content,
+    source  => $source,
+    target  => $target,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Class['systemd::systemctl::daemon_reload'],
+  }
+}

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'systemd::dropin_file' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        let(:title) { 'test.conf' }
+
+        let(:params) {{
+          :unit    => 'test.service',
+          :content => 'random stuff'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to create_file("#{params[:unit]}.d").with(
+          :ensure  => 'directory',
+          :path    => "/etc/systemd/system/#{params[:unit]}.d"
+        ) }
+
+        it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").with(
+          :ensure  => 'file',
+          :content => /#{params[:content]}/,
+          :mode    => '0444'
+        ) }
+
+        it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }
+
+        context 'with a bad unit type' do
+          let(:title) { 'test.badtype' }
+
+          it {
+            expect{
+              is_expected.to compile.with_all_deps
+            }.to raise_error(/expects a match for Systemd::Dropin/)
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -15,9 +15,8 @@ describe 'systemd::dropin_file' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to create_file("#{params[:unit]}.d").with(
+        it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d").with(
           :ensure  => 'directory',
-          :path    => "/etc/systemd/system/#{params[:unit]}.d"
         ) }
 
         it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").with(

--- a/types/dropin.pp
+++ b/types/dropin.pp
@@ -1,0 +1,1 @@
+type Systemd::Dropin = Pattern['^.+\.conf$']


### PR DESCRIPTION
Hi,

This solves #15. I know, there is another pull request, which manage drop-in files. But my solution is able to mange multiple drop-in files, even when the service file isn't managed by the `::systemd` module. I've also updated the spec tests and the README.

Regards