### PR TITLE
implement github changelog generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 sudo: false
 cache: bundler
-bundler_args: --without system_tests
+bundler_args: --without system_tests --without release
 script: ["bundle exec rake validate", "bundle exec rake lint", "bundle exec rake spec SPEC_OPTS='--format documentation'"]
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ group :development, :unit_tests do
   gem 'json_pure', '< 2.0.2',                              :require => false
 end
 
+group :release do
+  gem 'github_changelog_generator',                        :require => false, :git => 'https://github.com/skywinder/github-changelog-generator.git'
+end
+
 group :system_tests do
   gem 'beaker',               :require => false
   gem 'beaker-rspec', '> 5',  :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,16 @@ unless RUBY_VERSION =~ /^1\./
   require 'puppet_blacksmith'
   require 'puppet_blacksmith/rake_tasks'
 end
+
+begin
+  require 'github_changelog_generator/task'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    version = (Blacksmith::Modulefile.new).version
+    config.future_release = "#{version}" if version =~ /^\d+\.\d+.\d+$/
+    config.header = "# Changelog\n\n"
+    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
+    config.user = 'camptocamp'
+    config.project = 'puppet-systemd'
+  end
+rescue LoadError
+end


### PR DESCRIPTION
This is the code used to generate the changelog from #44. I am not sure if you want to have this in the module, or if you've a modulesync which would drop it. The used commit was tested on Vox Pupuli. Sadly there wasn't a working release in a longer time for the gem (but they are working on it)