### PR TITLE
Use the same systemd drop-in file for different units

### DIFF
--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -29,15 +29,14 @@
 #
 define systemd::dropin_file(
   Systemd::Unit                     $unit,
-  Enum['present', 'absent', 'file'] $ensure  = 'present',
-  Stdlib::Absolutepath              $path    = '/etc/systemd/system',
-  Optional[String]                  $content = undef,
-  Optional[String]                  $source  = undef,
-  Optional[Stdlib::Absolutepath]    $target  = undef,
+  Systemd::Dropin                   $filename = $name,
+  Enum['present', 'absent', 'file'] $ensure   = 'present',
+  Stdlib::Absolutepath              $path     = '/etc/systemd/system',
+  Optional[String]                  $content  = undef,
+  Optional[String]                  $source   = undef,
+  Optional[Stdlib::Absolutepath]    $target   = undef,
 ) {
   include ::systemd
-
-  assert_type(Systemd::Dropin, $name)
 
   if $target {
     $_ensure = 'link'
@@ -56,7 +55,7 @@ define systemd::dropin_file(
     })
   }
 
-  file { "${path}/${unit}.d/${name}":
+  file { "${path}/${unit}.d/${filename}":
     ensure  => $_ensure,
     content => $content,
     source  => $source,

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -38,18 +38,18 @@ describe 'systemd::dropin_file' do
         end
 
         context 'with explicit filename' do
-            let (:title) {'test'}
-            let (:params) {{
-                :filename => 'test.conf',
-                :unit     => 'test.service',
-                :content  => 'random stuff'
-            }}
+          let (:title) {'test'}
+          let (:params) {{
+            :filename => 'test.conf',
+            :unit     => 'test.service',
+            :content  => 'random stuff'
+          }}
 
-            it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{params[:filename]}").with(
-              :ensure  => 'file',
-              :content => /#{params[:content]}/,
-              :mode    => '0444'
-            ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{params[:filename]}").with(
+            :ensure  => 'file',
+            :content => /#{params[:content]}/,
+            :mode    => '0444'
+          ) }
         end
       end
     end

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -37,13 +37,27 @@ describe 'systemd::dropin_file' do
           }
         end
 
-        context 'with explicit filename' do
-          let (:title) {'test'}
-          let (:params) {{
-            :filename => 'test.conf',
-            :unit     => 'test.service',
+        context 'with another drop-in file with the same filename (and content)' do
+          let(:default_params) {{
+            :filename => 'longer-timeout.conf',
             :content  => 'random stuff'
           }}
+          # Create drop-in file longer-timeout.conf for unit httpd.service
+          let :pre_condition do
+            "systemd::dropin_file { 'httpd_longer-timeout':
+              filename => '#{default_params[:filename]}',
+              unit     => 'httpd.service',
+              content  => '#{default_params[:context]}',
+            }"
+          end
+          #
+          # Create drop-in file longer-timeout.conf for unit ftp.service
+          let (:title) {'ftp_longer-timeout'}
+          let :params do
+            default_params.merge({
+              :unit     => 'ftp.service'
+            })
+          end
 
           it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{params[:filename]}").with(
             :ensure  => 'file',

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -36,6 +36,21 @@ describe 'systemd::dropin_file' do
             }.to raise_error(/expects a match for Systemd::Dropin/)
           }
         end
+
+        context 'with explicit filename' do
+            let (:title) {'test'}
+            let (:params) {{
+                :filename => 'test.conf',
+                :unit     => 'test.service',
+                :content  => 'random stuff'
+            }}
+
+            it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{params[:filename]}").with(
+              :ensure  => 'file',
+              :content => /#{params[:content]}/,
+              :mode    => '0444'
+            ) }
+        end
       end
     end
   end


### PR DESCRIPTION
If you wan't to use the same systemd drop-in file for different systemd units, you have to come up with some artificial title for the ::systemd::dropin_file resource. This is because the $name is used as filename. Hence you get a duplicate definition if you want to use the same drop_in file for different units.

Now there is a filename parameter were you can set the filename explicit different from the resource title.