### PR TITLE
Use a space-separated in timesyncd.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ It is possible to configure the default ntp servers in /etc/systemd/timesyncd.co
 ```puppet
 class{'::systemd':
   $manage_timesyncd => true,
-  $ntp_server          => '0.pool.ntp.org,1.pool.ntp.org',
-  $fallback_ntp_server => '2.pool.ntp.org,3.pool.ntp.org',
+  $ntp_server          => '0.pool.ntp.org 1.pool.ntp.org',
+  $fallback_ntp_server => '2.pool.ntp.org 3.pool.ntp.org',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ It is possible to configure the default ntp servers in /etc/systemd/timesyncd.co
 ```puppet
 class{'::systemd':
   $manage_timesyncd => true,
-  $ntp_server          => '0.pool.ntp.org 1.pool.ntp.org',
-  $fallback_ntp_server => '2.pool.ntp.org 3.pool.ntp.org',
+  $ntp_server          => ['0.pool.ntp.org', '1.pool.ntp.org'],
+  $fallback_ntp_server => ['2.pool.ntp.org', '3.pool.ntp.org'],
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,8 +40,8 @@ class systemd (
   Enum['stopped','running']        $networkd_ensure  = 'running',
   Boolean                          $manage_timesyncd = false,
   Enum['stopped','running']        $timesyncd_ensure = 'running',
-  Optional[String] $ntp_server                       = undef,
-  Optional[String] $fallback_ntp_server              = undef,
+  Optional[Variant[Array,String]] $ntp_server          = undef,
+  Optional[Variant[Array,String]] $fallback_ntp_server = undef,
 ){
 
   contain ::systemd::systemctl::daemon_reload

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -6,7 +6,7 @@
 #   The state that the ``networkd`` service should be in
 #
 # @param $ntp_server
-#   comma separated list of ntp servers, will be combined with interface specific
+#   A space-separated list of NTP servers, will be combined with interface specific
 #   addresses from systemd-networkd. requires puppetlabs-inifile
 #
 # @param fallback_ntp_server
@@ -36,7 +36,7 @@ class systemd::timesyncd (
     if $ntp_server =~ String {
       $_ntp_server = $ntp_server
     } else {
-      $_ntp_server = join($ntp_server, ',')
+      $_ntp_server = join($ntp_server, ' ')
     }
     ini_setting{'ntp_server':
       ensure  => 'present',
@@ -52,7 +52,7 @@ class systemd::timesyncd (
     if $fallback_ntp_server =~ String {
       $_fallback_ntp_server = $fallback_ntp_server
     } else {
-      $_fallback_ntp_server = join($fallback_ntp_server, ',')
+      $_fallback_ntp_server = join($fallback_ntp_server, ' ')
     }
     ini_setting{'fallback_ntp_server':
       ensure  => 'present',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -37,11 +37,22 @@ describe 'systemd' do
           it { is_expected.not_to create_service('systemd-networkd').with_enable(true) }
         end
 
-        context 'when enabling timesyncd with NTP values' do
+        context 'when enabling timesyncd with NTP values (string)' do
           let(:params) {{
             :manage_timesyncd => true,
             :ntp_server => '0.pool.ntp.org 1.pool.ntp.org',
             :fallback_ntp_server => '2.pool.ntp.org 3.pool.ntp.org'
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_ini_setting('ntp_server')}
+          it { is_expected.to contain_ini_setting('fallback_ntp_server')}
+        end
+
+        context 'when enabling timesyncd with NTP values (array)' do
+          let(:params) {{
+            :manage_timesyncd => true,
+            :ntp_server => %w(0.pool.ntp.org 1.pool.ntp.org),
+            :fallback_ntp_server => %w(2.pool.ntp.org 3.pool.ntp.org)
           }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_ini_setting('ntp_server')}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,8 +40,8 @@ describe 'systemd' do
         context 'when enabling timesyncd with NTP values' do
           let(:params) {{
             :manage_timesyncd => true,
-            :ntp_server => '0.pool.ntp.org,1.pool.ntp.org',
-            :fallback_ntp_server => '2.pool.ntp.org,3.pool.ntp.org'
+            :ntp_server => '0.pool.ntp.org 1.pool.ntp.org',
+            :fallback_ntp_server => '2.pool.ntp.org 3.pool.ntp.org'
           }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_ini_setting('ntp_server')}


### PR DESCRIPTION
According to timesyncd.conf(5) in man, NTP and FallbackNTP need a space-separated list: https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html