### PR TITLE
Use Hash for $service_limits of systemd class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@
 #   as the fallback NTP servers. Any per-interface NTP servers obtained from
 #   systemd-networkd take precedence over this setting. requires puppetlabs-inifile
 class systemd (
-  Optional[Systemd::ServiceLimits] $service_limits   = undef,
+  Hash                             $service_limits   = {},
   Boolean                          $manage_resolved  = false,
   Enum['stopped','running']        $resolved_ensure  = 'running',
   Boolean                          $manage_networkd  = false,


### PR DESCRIPTION
`create_resource('systemd::service_limits', $service_limits)` of systemd class (init.pp) fails unless `$service_limits` is set to Hash.