### PR TITLE
Purge another NTP daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ class{'::systemd':
   $manage_timesyncd => true,
   $ntp_server          => ['0.pool.ntp.org', '1.pool.ntp.org'],
   $fallback_ntp_server => ['2.pool.ntp.org', '3.pool.ntp.org'],
+  $purge_another_ntp_daemon => true,
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,9 @@
 #   A space-separated list of NTP server host names or IP addresses to be used
 #   as the fallback NTP servers. Any per-interface NTP servers obtained from
 #   systemd-networkd take precedence over this setting. requires puppetlabs-inifile
+#
+# @param purge_another_ntp_daemon
+#   Determine to purge another NTP daemon
 class systemd (
   Hash[String, Hash[String, Any]]  $service_limits   = {},
   Boolean                          $manage_resolved  = false,
@@ -42,6 +45,7 @@ class systemd (
   Enum['stopped','running']        $timesyncd_ensure = 'running',
   Optional[Variant[Array,String]] $ntp_server          = undef,
   Optional[Variant[Array,String]] $fallback_ntp_server = undef,
+  Boolean $purge_another_ntp_daemon                    = false,
 ){
 
   contain ::systemd::systemctl::daemon_reload

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class systemd (
   Optional[Variant[Array,String]] $ntp_server          = undef,
   Optional[Variant[Array,String]] $fallback_ntp_server = undef,
   Boolean $purge_another_ntp_daemon                    = false,
+  Array $purge_ntp_packages                            = ['ntp', 'chrony', 'openntpd'],
 ){
 
   contain ::systemd::systemctl::daemon_reload

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@
 #
 # @param purge_another_ntp_daemon
 #   Determine to purge another NTP daemon
+#
+# @param purge_ntp_packages
+#   A list of packages should be purged
+#
 class systemd (
   Hash[String, Hash[String, Any]]  $service_limits   = {},
   Boolean                          $manage_resolved  = false,

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -13,13 +13,28 @@
 #   A space-separated list of NTP server host names or IP addresses to be used
 #   as the fallback NTP servers. Any per-interface NTP servers obtained from
 #   systemd-networkd take precedence over this setting. requires puppetlabs-inifile
+#
+# @param purge_another_ntp_daemon
+#   Determine to purge another NTP daemon
 class systemd::timesyncd (
   Enum['stopped','running'] $ensure                    = $systemd::timesyncd_ensure,
   Optional[Variant[Array,String]] $ntp_server          = $systemd::ntp_server,
   Optional[Variant[Array,String]] $fallback_ntp_server = $systemd::fallback_ntp_server,
+  Boolean $purge_another_ntp_daemon                    = $systemd::purge_another_ntp_daemon,
 ){
 
   assert_private()
+
+  if $purge_another_ntp_daemon {
+    package { [
+      'ntp',
+      'chrony',
+      'openntpd',
+    ]:
+      ensure  => absent,
+      require => Service['systemd-timesyncd'],
+    }
+  }
 
   $_enable_timesyncd = $ensure ? {
     'stopped' => false,

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -16,21 +16,22 @@
 #
 # @param purge_another_ntp_daemon
 #   Determine to purge another NTP daemon
+#
+# @param purge_ntp_packages
+#   A list of packages should be purged
+#
 class systemd::timesyncd (
   Enum['stopped','running'] $ensure                    = $systemd::timesyncd_ensure,
   Optional[Variant[Array,String]] $ntp_server          = $systemd::ntp_server,
   Optional[Variant[Array,String]] $fallback_ntp_server = $systemd::fallback_ntp_server,
   Boolean $purge_another_ntp_daemon                    = $systemd::purge_another_ntp_daemon,
+  Array $purge_ntp_packages                            = $systemd::purge_ntp_packages,
 ){
 
   assert_private()
 
   if $purge_another_ntp_daemon {
-    package { [
-      'ntp',
-      'chrony',
-      'openntpd',
-    ]:
+    package { $purge_ntp_packages:
       ensure => absent,
       before => Service['systemd-timesyncd'],
     }

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -31,8 +31,8 @@ class systemd::timesyncd (
       'chrony',
       'openntpd',
     ]:
-      ensure  => absent,
-      require => Service['systemd-timesyncd'],
+      ensure => absent,
+      before => Service['systemd-timesyncd'],
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -37,7 +37,7 @@ describe 'systemd' do
           it { is_expected.not_to create_service('systemd-networkd').with_enable(true) }
         end
 
-        context 'when enabling timesyncd' do
+        context 'when enabling timesyncd with purge packages (default)' do
           let(:params) {{
             :manage_timesyncd => true,
             :purge_another_ntp_daemon => true
@@ -48,6 +48,20 @@ describe 'systemd' do
           it { is_expected.to create_package('ntp').with_ensure('absent') }
           it { is_expected.to create_package('chrony').with_ensure('absent') }
           it { is_expected.to create_package('openntpd').with_ensure('absent') }
+        end
+
+        context 'when enabling timesyncd with purge packages (specified packages)' do
+          let(:params) {{
+            :manage_timesyncd => true,
+            :purge_another_ntp_daemon => true
+            :purge_ntp_packages = %w(ntp chrony),
+          }}
+
+          it { is_expected.to create_service('systemd-timesyncd').with_ensure('running') }
+          it { is_expected.to create_service('systemd-timesyncd').with_enable(true) }
+          it { is_expected.to create_package('ntp').with_ensure('absent') }
+          it { is_expected.to create_package('chrony').with_ensure('absent') }
+          it { is_expected.not_to create_package('openntpd').with_ensure('absent') }
         end
 
         context 'when enabling timesyncd with NTP values (string)' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -53,7 +53,7 @@ describe 'systemd' do
         context 'when enabling timesyncd with purge packages (specified packages)' do
           let(:params) {{
             :manage_timesyncd => true,
-            :purge_another_ntp_daemon => true
+            :purge_another_ntp_daemon => true,
             :purge_ntp_packages = %w(ntp chrony),
           }}
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -54,7 +54,7 @@ describe 'systemd' do
           let(:params) {{
             :manage_timesyncd => true,
             :purge_another_ntp_daemon => true,
-            :purge_ntp_packages = %w(ntp chrony),
+            :purge_ntp_packages => %w(ntp chrony),
           }}
 
           it { is_expected.to create_service('systemd-timesyncd').with_ensure('running') }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -37,6 +37,19 @@ describe 'systemd' do
           it { is_expected.not_to create_service('systemd-networkd').with_enable(true) }
         end
 
+        context 'when enabling timesyncd' do
+          let(:params) {{
+            :manage_timesyncd => true,
+            :purge_another_ntp_daemon => true
+          }}
+
+          it { is_expected.to create_service('systemd-timesyncd').with_ensure('running') }
+          it { is_expected.to create_service('systemd-timesyncd').with_enable(true) }
+          it { is_expected.to create_package('ntp').with_ensure('absent') }
+          it { is_expected.to create_package('chrony').with_ensure('absent') }
+          it { is_expected.to create_package('openntpd').with_ensure('absent') }
+        end
+
         context 'when enabling timesyncd with NTP values (string)' do
           let(:params) {{
             :manage_timesyncd => true,


### PR DESCRIPTION
In debian stretch or ubuntu xenial, systemd-timesyncd don't run if host has installed another NTP daemon:

```
root@987337e94ce5:/# cat /lib/systemd/system/systemd-timesyncd.service.d/disable-with-time-daemon.conf
[Unit]
# don't run timesyncd if we have another NTP daemon installed
ConditionFileIsExecutable=!/usr/sbin/ntpd
ConditionFileIsExecutable=!/usr/sbin/openntpd
ConditionFileIsExecutable=!/usr/sbin/chronyd
ConditionFileIsExecutable=!/usr/sbin/VBoxService
```

This commit allows to purge NTPd packages (default false).