### PR TITLE
Replace iterator with stdlib function

### DIFF
--- a/manifests/tmpfiles.pp
+++ b/manifests/tmpfiles.pp
@@ -14,7 +14,7 @@ class systemd::tmpfiles (
   Array[Enum['create','clean','remove']] $operations = ['create']
 ) {
 
-  $_ops = join($operations.map |$op| { "--${op}" }, ' ')
+  $_ops = join(prefix($operations, '--'), ' ')
 
   exec { 'systemd-tmpfiles':
     command     => "systemd-tmpfiles ${_ops}",


### PR DESCRIPTION
If I understand correctly, this line does what `stdlib`'s `prefix` does so I replaced it.