### PR TITLE
Reuse the systemd::dropin_file in service_limits

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -54,27 +54,13 @@ define systemd::service_limits(
     fail('You must supply either the limits or source parameter to systemd::service_limits')
   }
 
-  file { "${path}/${name}.d/":
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    seltype => 'systemd_unit_file_t',
-  }
-
-  $_conf_file_ensure = $ensure ? {
-    'present' => 'file',
-    default   => $ensure,
-  }
-
-  file { "${path}/${name}.d/90-limits.conf":
-    ensure  => $_conf_file_ensure,
-    content => $_content,
-    source  => $source,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    notify  => Class['systemd::systemctl::daemon_reload'],
+  systemd::dropin_file { "${name}-90-limits.conf":
+    ensure   => $ensure,
+    unit     => $name,
+    filename => '90-limits.conf',
+    path     => $path,
+    content  => $_content,
+    source   => $source,
   }
 
   if $restart_service {

--- a/spec/defines/service_limits_spec.rb
+++ b/spec/defines/service_limits_spec.rb
@@ -30,7 +30,7 @@ describe 'systemd::service_limits' do
         it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
           :ensure  => 'file',
           :content => /LimitCPU=10m/,
-          :mode    => '0644'
+          :mode    => '0444'
         ) }
         it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
           :content => /LimitFSIZE=infinity/


### PR DESCRIPTION
This reduces duplication and fixes a potential duplicate resource of the unit drop in directory.