### PR TITLE
purge legacy puppet-lint checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development, :unit_tests do
   gem 'puppet-lint-unquoted_string-check',                 :require => false
   gem 'puppet-lint-empty_string-check',                    :require => false
   gem 'puppet-lint-spaceship_operator_without_tag-check',  :require => false
-  gem 'puppet-lint-absolute_classname-check',              :require => false
   gem 'puppet-lint-undef_in_function-check',               :require => false
   gem 'puppet-lint-leading_zero-check',                    :require => false
   gem 'puppet-lint-trailing_comma-check',                  :require => false

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -36,7 +36,7 @@ define systemd::dropin_file(
   Optional[String]                  $source   = undef,
   Optional[Stdlib::Absolutepath]    $target   = undef,
 ) {
-  include ::systemd
+  include systemd
 
   if $target {
     $_ensure = 'link'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,19 +44,19 @@ class systemd (
   Optional[Variant[Array,String]] $fallback_ntp_server = undef,
 ){
 
-  contain ::systemd::systemctl::daemon_reload
+  contain systemd::systemctl::daemon_reload
 
   create_resources('systemd::service_limits', $service_limits)
 
   if $manage_resolved and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-resolved.service'] {
-    contain ::systemd::resolved
+    contain systemd::resolved
   }
 
   if $manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
-    contain ::systemd::networkd
+    contain systemd::networkd
   }
 
   if $manage_timesyncd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-timesyncd.service'] {
-    contain ::systemd::timesyncd
+    contain systemd::timesyncd
   }
 }

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -9,7 +9,7 @@ define systemd::network (
   Boolean $restart_service               = true,
 ){
 
-  include ::systemd
+  include systemd
 
   if $restart_service and $systemd::manage_networkd {
     $notify = Service['systemd-networkd']

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -34,7 +34,7 @@ define systemd::service_limits(
   Boolean                           $restart_service = true
 ) {
 
-  include ::systemd
+  include systemd
 
   if $name !~ Pattern['^.+\.(service|socket|mount|swap)$'] {
     fail('$name must match Pattern["^.+\.(service|socket|mount|swap)$"]')

--- a/manifests/tmpfile.pp
+++ b/manifests/tmpfile.pp
@@ -31,7 +31,7 @@ define systemd::tmpfile(
   Optional[String]                  $content = undef,
   Optional[String]                  $source  = undef,
 ) {
-  include ::systemd::tmpfiles
+  include systemd::tmpfiles
 
   if $name =~ Pattern['/'] {
     fail('$name may not contain a forward slash "(/)"')

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -34,7 +34,7 @@ define systemd::unit_file(
   Optional[String]                  $source  = undef,
   Optional[Stdlib::Absolutepath]    $target  = undef,
 ) {
-  include ::systemd
+  include systemd
 
   assert_type(Systemd::Unit, $name)
 


### PR DESCRIPTION
this check isn't needed anymore for puppet4 and newer