### PR TITLE
move params to data-in-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This module declares exec resources to create global sync points for reloading systemd.
 
+**Version 2 and newer of the module don't work with Hiera 3! You need to migrate your existing Hiera setup to Hiera 5**
+
 ## Usage and examples
 
 There are two ways to use this module.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,10 @@
+---
+systemd::service_limits: {}
+systemd::manage_resolved: false
+systemd::resolved_ensure: 'running'
+systemd::manage_networkd: false
+systemd::networkd_ensure: 'running'
+systemd::manage_timesyncd: false
+systemd::timesyncd_ensure: 'running'
+systemd::ntp_server: ~
+systemd::fallback_ntp_server: ~

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,12 @@
+---
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+hierarchy:
+  - name: 'Major Version'
+    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
+  - name: 'Distribution Name'
+    path: '%{facts.os.name}.yaml'
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,15 +33,15 @@
 #   as the fallback NTP servers. Any per-interface NTP servers obtained from
 #   systemd-networkd take precedence over this setting. requires puppetlabs-inifile
 class systemd (
-  Hash[String, Hash[String, Any]]  $service_limits   = {},
-  Boolean                          $manage_resolved  = false,
-  Enum['stopped','running']        $resolved_ensure  = 'running',
-  Boolean                          $manage_networkd  = false,
-  Enum['stopped','running']        $networkd_ensure  = 'running',
-  Boolean                          $manage_timesyncd = false,
-  Enum['stopped','running']        $timesyncd_ensure = 'running',
-  Optional[Variant[Array,String]] $ntp_server          = undef,
-  Optional[Variant[Array,String]] $fallback_ntp_server = undef,
+  Hash[String, Hash[String, Any]] $service_limits,
+  Boolean                         $manage_resolved,
+  Enum['stopped','running']       $resolved_ensure,
+  Boolean                         $manage_networkd,
+  Enum['stopped','running']       $networkd_ensure,
+  Boolean                         $manage_timesyncd,
+  Enum['stopped','running']       $timesyncd_ensure,
+  Optional[Variant[Array,String]] $ntp_server,
+  Optional[Variant[Array,String]] $fallback_ntp_server,
 ){
 
   contain systemd::systemctl::daemon_reload

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.10.10 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This got pulled out of https://github.com/camptocamp/puppet-systemd/pull/65. The lowest recommended puppet version for this is 4.10.10. In the Vox Pupuli namespace we had a lot of argumentation if this requires a major version bump or not. From a point of defensive programming this should be a major bump.