### PR TITLE
Add enable and active parameters to unit_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Let this module handle file creation and systemd reloading.
 systemd::unit_file { 'foo.service':
  source => "puppet:///modules/${module_name}/foo.service",
 } ~> service {'foo':
- ensure => running,
+  ensure => 'running',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Let this module handle file creation and systemd reloading.
 systemd::unit_file { 'foo.service':
  source => "puppet:///modules/${module_name}/foo.service",
 } ~> service {'foo':
-  ensure => 'running',
+ ensure => running,
 }
 ```
 
@@ -39,6 +39,16 @@ file { '/usr/lib/systemd/system/foo.service':
 service {'foo':
   ensure    => 'running',
   subscribe => File['/usr/lib/systemd/system/foo.service'],
+}
+```
+
+You can also use this module to more fully manage the new unit. This example deploys the unit, reloads systemd and then enables and starts it.
+
+```puppet
+systemd::unit_file { 'foo.service':
+ source => "puppet:///modules/${module_name}/foo.service",
+ enable => true,
+ active => true,
 }
 ```
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -27,12 +27,20 @@
 #
 #   * Mutually exclusive with both ``$source`` and ``$content``
 #
+# @attr enable
+#   If set, will manage the unit enablement status.
+#
+# @attr active
+#   If set, will manage the state of the unit.
+#
 define systemd::unit_file(
-  Enum['present', 'absent', 'file'] $ensure  = 'present',
-  Stdlib::Absolutepath              $path    = '/etc/systemd/system',
-  Optional[String]                  $content = undef,
-  Optional[String]                  $source  = undef,
-  Optional[Stdlib::Absolutepath]    $target  = undef,
+  Enum['present', 'absent', 'file']        $ensure  = 'present',
+  Stdlib::Absolutepath                     $path    = '/etc/systemd/system',
+  Optional[String]                         $content = undef,
+  Optional[String]                         $source  = undef,
+  Optional[Stdlib::Absolutepath]           $target  = undef,
+  Optional[Variant[Boolean, Enum['mask']]] $enable  = undef,
+  Optional[Boolean]                        $active  = undef,
 ) {
   include systemd
 
@@ -56,5 +64,15 @@ define systemd::unit_file(
     group   => 'root',
     mode    => '0444',
     notify  => Class['systemd::systemctl::daemon_reload'],
+  }
+
+  if $enable != undef or $active != undef {
+    service { $name:
+      ensure    => $active,
+      enable    => $enable,
+      provider  => 'systemd',
+      subscribe => File["${path}/${name}"],
+      require   => Class['systemd::systemctl::daemon_reload'],
+    }
   }
 }

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -31,6 +31,24 @@ describe 'systemd::unit_file' do
             }.to raise_error(/expects a match for Systemd::Unit/)
           }
         end
+
+        context 'with enable => true and active => true' do
+          let(:params) do
+            super().merge({
+              :enable => true,
+              :active => true
+            })
+          end
+
+          it { is_expected.to contain_service('test.service').with(
+            :ensure   => true,
+            :enable   => true,
+            :provider => 'systemd'
+          ) }
+
+          it { is_expected.to contain_service('test.service').that_subscribes_to("File[/etc/systemd/system/#{title}]") }
+          it { is_expected.to contain_service('test.service').that_requires('Class[systemd::systemctl::daemon_reload]') }
+        end
       end
     end
   end


### PR DESCRIPTION
Allows the deployed units to be enabled and/or started by the module. By default it will leave the units unmanaged.

This is an attempt to supersede PR #55 for which the original submitter appears to have lost interest.