### PR TITLE
bump facter to latest 2.x version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
 else
   # There are no facts in place for facter > 2.4 in rspec-puppet-facts yet
-  gem 'facter', '~> 2.4.0', :require => false
+  gem 'facter', '~> 2.5.0', :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
It isn't necessary to pin it, facterdb now has all needed facts for 2.5