### PR TITLE
add ubuntu 18.04 support

### DIFF
--- a/data/Ubuntu-18.04.yaml
+++ b/data/Ubuntu-18.04.yaml
@@ -1,0 +1,8 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {


### PR DESCRIPTION
We should wait with this until Ubuntu 18.04 is released as a stable version and facterdb has suitable facts.