### PR TITLE
Remain compatible with older Puppet 4.x releases

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,12 +1,13 @@
 ---
 version: 5
-defaults:
-  datadir: 'data'
-  data_hash: 'yaml_data'
+datadir: 'data'
 hierarchy:
   - name: 'Major Version'
+    backend: 'yaml'
     path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
   - name: 'Distribution Name'
+    backend: 'yaml'
     path: '%{facts.os.name}.yaml'
   - name: 'common'
+    backend: 'yaml'
     path: 'common.yaml'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,5 @@
 ---
-version: 5
+version: 4
 datadir: 'data'
 hierarchy:
   - name: 'Major Version'

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/camptocamp/puppet-systemd",
   "project_page": "https://github.com/camptocamp/puppet-systemd",
   "issues_url": "https://github.com/camptocamp/puppet-systemd/issues",
+  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
@@ -16,7 +17,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.10 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Puppet supports data-in-modules since 4.3, although the metadata syntax has changed a little bit. With these changes, the module can keep evolving with the current data-in-modules scheme while staying compatible with older Puppet 4 releases.

Once it's decided to completely drop Puppet 4 support, only small changes will be required.