### PR TITLE
Add parameter to select resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ $manage_networkd is required if you want to reload it for new
 `systemd::network` resources. Setting $manage_resolved will also manage your
 `/etc/resolv.conf`.
 
+When configuring `systemd::resolved` you could set `dns_stub_resolver` to false (default) to use a *standard* `/etc/resolved.conf`, or you could set it to `true` to use the local resolver provided by `systemd-resolved`.
+
 It is possible to configure the default ntp servers in /etc/systemd/timesyncd.conf:
 
 ```puppet

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,7 @@ systemd::multicast_dns: ~
 systemd::dnssec: ~
 systemd::cache: false
 systemd::dns_stub_listener: ~
+systemd::use_stub_resolver: false
 systemd::manage_networkd: false
 systemd::networkd_ensure: 'running'
 systemd::manage_timesyncd: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,9 @@
 # @param dns_stub_listener
 #   Takes a boolean argument or one of "udp" and "tcp".
 #
+# @param use_stub_resolver
+#   Takes a boolean argument. When "false" (default) it uses /var/run/systemd/resolve/resolv.conf
+#   as /etc/resolv.conf. When "true", it uses /var/run/systemd/resolve/stub-resolv.conf
 # @param manage_networkd
 #   Manage the systemd network daemon
 #
@@ -74,6 +77,7 @@ class systemd (
   Optional[Variant[Boolean,Enum['allow-downgrade']]] $dnssec,
   Boolean                                            $cache,
   Optional[Variant[Boolean,Enum['udp','tcp']]]       $dns_stub_listener,
+  Boolean                                            $use_stub_resolver,
   Boolean                                            $manage_networkd,
   Enum['stopped','running']                          $networkd_ensure,
   Boolean                                            $manage_timesyncd,


### PR DESCRIPTION
When using systemd-resolver you can choose to link /etc/resolv.conf to
a "standard" resolv.conf or to a "stub-resolv.conf" that uses 127.0.0.53
resolver provided by it.