### PR TITLE
Handle ensuring service_limits to be absent

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -47,11 +47,13 @@ define systemd::service_limits(
     $_content = undef
   }
 
-  if ($limits and !empty($limits)) and $source {
-    fail('You may not supply both limits and source parameters to systemd::service_limits')
-  }
-  elsif ($limits == undef or empty($limits)) and ($source == undef) {
-    fail('You must supply either the limits or source parameter to systemd::service_limits')
+  if $ensure != 'absent' {
+    if ($limits and !empty($limits)) and $source {
+      fail('You may not supply both limits and source parameters to systemd::service_limits')
+    }
+    elsif ($limits == undef or empty($limits)) and ($source == undef) {
+      fail('You must supply either the limits or source parameter to systemd::service_limits')
+    }
   }
 
   systemd::dropin_file { "${name}-90-limits.conf":

--- a/spec/defines/service_limits_spec.rb
+++ b/spec/defines/service_limits_spec.rb
@@ -8,58 +8,78 @@ describe 'systemd::service_limits' do
 
         let(:title) { 'test.service' }
 
-        let(:params) {{
-          :limits => {
-            'LimitCPU'    => '10m',
-            'LimitFSIZE'  => 'infinity',
-            'LimitDATA'   => '10K',
-            'LimitNOFILE' => 20,
-            'LimitNICE'   => '-10',
-            'LimitRTPRIO' => 50,
-            'IODeviceWeight' => [
-              {'/dev/weight' => 10},
-              {'/dev/weight2' => 20}
-            ],
-            'IOReadBandwidthMax' => [
-              {'/bw/max' => '10K'}
-            ]
-          }
-        }}
+        describe 'with limits and present' do
+          let(:params) {{
+            :limits => {
+              'LimitCPU'    => '10m',
+              'LimitFSIZE'  => 'infinity',
+              'LimitDATA'   => '10K',
+              'LimitNOFILE' => 20,
+              'LimitNICE'   => '-10',
+              'LimitRTPRIO' => 50,
+              'IODeviceWeight' => [
+                {'/dev/weight' => 10},
+                {'/dev/weight2' => 20}
+              ],
+              'IOReadBandwidthMax' => [
+                {'/bw/max' => '10K'}
+              ]
+            }
+          }}
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :ensure  => 'file',
-          :content => /LimitCPU=10m/,
-          :mode    => '0444'
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => /LimitFSIZE=infinity/
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => /LimitDATA=10K/
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => /LimitNOFILE=20/
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => /LimitNICE=-10/
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => /LimitRTPRIO=50/
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => %r(IODeviceWeight=/dev/weight 10)
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => %r(IODeviceWeight=/dev/weight2 20)
-        ) }
-        it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
-          :content => %r(IOReadBandwidthMax=/bw/max 10K)
-        ) }
-        it { is_expected.to create_exec("restart #{title} because limits").with(
-          :command => "systemctl restart #{title}",
-          :refreshonly => true
-        ) }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :ensure  => 'file',
+              :content => /LimitCPU=10m/,
+              :mode    => '0444'
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => /LimitFSIZE=infinity/
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => /LimitDATA=10K/
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => /LimitNOFILE=20/
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => /LimitNICE=-10/
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => /LimitRTPRIO=50/
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => %r(IODeviceWeight=/dev/weight 10)
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => %r(IODeviceWeight=/dev/weight2 20)
+          ) }
+          it { is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").with(
+            :content => %r(IOReadBandwidthMax=/bw/max 10K)
+          ) }
+          it { is_expected.to create_exec("restart #{title} because limits").with(
+            :command => "systemctl restart #{title}",
+            :refreshonly => true
+          ) }
+        end
+
+        describe 'ensured absent' do
+          let(:params) {{
+            :ensure => 'absent',
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf")
+              .with_ensure('absent')
+              .that_notifies("Exec[restart #{title} because limits]")
+          end
+          it do
+            is_expected.to create_exec("restart #{title} because limits")
+              .with_command("systemctl restart #{title}")
+              .with_refreshonly(true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When ensuring it to be absent, the limits can be undefined since they
don't matter.