### PR TITLE
Add support for DNSoverTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ $manage_networkd is required if you want to reload it for new
 
 When configuring `systemd::resolved` you could set `dns_stub_resolver` to false (default) to use a *standard* `/etc/resolved.conf`, or you could set it to `true` to use the local resolver provided by `systemd-resolved`.
 
+Systemd has introduced `DNS Over TLS` in the release 239. Currently two states are supported `no` and `opportunistic`. When enabled with `opportunistic` `systemd-resolved` will start a TCP-session to a DNS server with `DNS Over TLS` support. Note that there will be no host checking for `DNS Over TLS` due to missing implementation in `systemd-resolved`.
+
 It is possible to configure the default ntp servers in /etc/systemd/timesyncd.conf:
 
 ```puppet

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,6 +8,7 @@ systemd::domains: ~
 systemd::llmnr: ~
 systemd::multicast_dns: ~
 systemd::dnssec: ~
+systemd::dnsovertls: false
 systemd::cache: false
 systemd::dns_stub_listener: ~
 systemd::use_stub_resolver: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,9 @@
 # @param dnssec
 #   Takes a boolean argument or "allow-downgrade".
 #
+# @param dnsovertls
+#   Takes a boolean argument or "opportunistic"
+#
 # @param cache
 #   Takes a boolean argument.
 #
@@ -66,26 +69,27 @@
 #   as the fallback NTP servers. Any per-interface NTP servers obtained from
 #   systemd-networkd take precedence over this setting. requires puppetlabs-inifile
 class systemd (
-  Hash[String,Hash[String, Any]]                     $service_limits,
-  Boolean                                            $manage_resolved,
-  Enum['stopped','running']                          $resolved_ensure,
-  Optional[Variant[Array[String],String]]            $dns,
-  Optional[Variant[Array[String],String]]            $fallback_dns,
-  Optional[Variant[Array[String],String]]            $domains,
-  Optional[Variant[Boolean,Enum['resolve']]]         $llmnr,
-  Optional[Variant[Boolean,Enum['resolve']]]         $multicast_dns,
-  Optional[Variant[Boolean,Enum['allow-downgrade']]] $dnssec,
-  Boolean                                            $cache,
-  Optional[Variant[Boolean,Enum['udp','tcp']]]       $dns_stub_listener,
-  Boolean                                            $use_stub_resolver,
-  Boolean                                            $manage_networkd,
-  Enum['stopped','running']                          $networkd_ensure,
-  Boolean                                            $manage_timesyncd,
-  Enum['stopped','running']                          $timesyncd_ensure,
-  Optional[Variant[Array,String]]                    $ntp_server,
-  Optional[Variant[Array,String]]                    $fallback_ntp_server,
-  Boolean                                            $manage_accounting,
-  Hash[String,String]                                $accounting,
+  Hash[String,Hash[String, Any]]                         $service_limits,
+  Boolean                                                $manage_resolved,
+  Enum['stopped','running']                              $resolved_ensure,
+  Optional[Variant[Array[String],String]]                $dns,
+  Optional[Variant[Array[String],String]]                $fallback_dns,
+  Optional[Variant[Array[String],String]]                $domains,
+  Optional[Variant[Boolean,Enum['resolve']]]             $llmnr,
+  Optional[Variant[Boolean,Enum['resolve']]]             $multicast_dns,
+  Optional[Variant[Boolean,Enum['allow-downgrade']]]     $dnssec,
+  Optional[Variant[Boolean,Enum['opportunistic', 'no']]] $dnsovertls,
+  Boolean                                                $cache,
+  Optional[Variant[Boolean,Enum['udp','tcp']]]           $dns_stub_listener,
+  Boolean                                                $use_stub_resolver,
+  Boolean                                                $manage_networkd,
+  Enum['stopped','running']                              $networkd_ensure,
+  Boolean                                                $manage_timesyncd,
+  Enum['stopped','running']                              $timesyncd_ensure,
+  Optional[Variant[Array,String]]                        $ntp_server,
+  Optional[Variant[Array,String]]                        $fallback_ntp_server,
+  Boolean                                                $manage_accounting,
+  Hash[String,String]                                    $accounting,
 ){
 
   contain systemd::systemctl::daemon_reload

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,6 +40,7 @@ describe 'systemd' do
           it { is_expected.not_to contain_ini_setting('multicast_dns')}
           it { is_expected.not_to contain_ini_setting('llmnr')}
           it { is_expected.not_to contain_ini_setting('dnssec')}
+          it { is_expected.not_to contain_ini_setting('dnsovertls')}
           it { is_expected.not_to contain_ini_setting('cache')}
           it { is_expected.not_to contain_ini_setting('dns_stub_listener')}
         end
@@ -59,6 +60,7 @@ describe 'systemd' do
           it { is_expected.not_to contain_ini_setting('multicast_dns')}
           it { is_expected.not_to contain_ini_setting('llmnr')}
           it { is_expected.not_to contain_ini_setting('dnssec')}
+          it { is_expected.not_to contain_ini_setting('dnsovertls')}
           it { is_expected.not_to contain_ini_setting('cache')}
           it { is_expected.not_to contain_ini_setting('dns_stub_listener')}
         end
@@ -72,6 +74,7 @@ describe 'systemd' do
             :llmnr => true,
             :multicast_dns => false,
             :dnssec => false,
+            :dnsovertls => 'no',
             :cache => true,
             :dns_stub_listener => 'udp',
           }}
@@ -84,6 +87,7 @@ describe 'systemd' do
           it { is_expected.to contain_ini_setting('multicast_dns')}
           it { is_expected.to contain_ini_setting('llmnr')}
           it { is_expected.to contain_ini_setting('dnssec')}
+          it { is_expected.to contain_ini_setting('dnsovertls')}
           it { is_expected.to contain_ini_setting('cache')}
           it { is_expected.to contain_ini_setting('dns_stub_listener')}
         end


### PR DESCRIPTION
systemd-resolved supports DNSOverTLS since version 239.
Current Options for this feature are:

*  'opportunistic'
*  'no'

There will be a 'strict' or 'yes' feature in the future.

Signed-off-by: Christian Rebischke <chris@nullday.de>