### PR TITLE
Allow specifying owner/group/mode/show_diff

### DIFF
--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -37,7 +37,7 @@
 #   The mode to set on the dropin file
 #
 # @attr show_diff
-#   Wether to show the diff when updating dropin file
+#   Whether to show the diff when updating dropin file
 #
 define systemd::dropin_file(
   Systemd::Unit                     $unit,

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -27,14 +27,30 @@
 #
 #   * Mutually exclusive with both ``$source`` and ``$content``
 #
+# @attr owner
+#   The owner to set on the dropin file
+#
+# @attr group
+#   The group to set on the dropin file
+#
+# @attr mode
+#   The mode to set on the dropin file
+#
+# @attr show_diff
+#   Wether to show the diff when updating dropin file
+#
 define systemd::dropin_file(
   Systemd::Unit                     $unit,
-  Systemd::Dropin                   $filename = $name,
-  Enum['present', 'absent', 'file'] $ensure   = 'present',
-  Stdlib::Absolutepath              $path     = '/etc/systemd/system',
-  Optional[String]                  $content  = undef,
-  Optional[String]                  $source   = undef,
-  Optional[Stdlib::Absolutepath]    $target   = undef,
+  Systemd::Dropin                   $filename  = $name,
+  Enum['present', 'absent', 'file'] $ensure    = 'present',
+  Stdlib::Absolutepath              $path      = '/etc/systemd/system',
+  Optional[String]                  $content   = undef,
+  Optional[String]                  $source    = undef,
+  Optional[Stdlib::Absolutepath]    $target    = undef,
+  String                            $owner     = 'root',
+  String                            $group     = 'root',
+  String                            $mode      = '0444',
+  Boolean                           $show_diff = true,
 ) {
   include systemd
 
@@ -58,13 +74,14 @@ define systemd::dropin_file(
   }
 
   file { "${path}/${unit}.d/${filename}":
-    ensure  => $_ensure,
-    content => $content,
-    source  => $source,
-    target  => $target,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0444',
-    notify  => Class['systemd::systemctl::daemon_reload'],
+    ensure    => $_ensure,
+    content   => $content,
+    source    => $source,
+    target    => $target,
+    owner     => $owner,
+    group     => $group,
+    mode      => $mode,
+    show_diff => $show_diff,
+    notify    => Class['systemd::systemctl::daemon_reload'],
   }
 }

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -1,12 +1,16 @@
 # -- Define: systemd::network
 # Creates network config for systemd-networkd
 define systemd::network (
-  Enum['file', 'absent'] $ensure         = file,
-  Stdlib::Absolutepath $path             = '/etc/systemd/network',
-  Optional[String] $content              = undef,
-  Optional[String] $source               = undef,
-  Optional[Stdlib::Absolutepath] $target = undef,
-  Boolean $restart_service               = true,
+  Enum['file', 'absent']         $ensure          = file,
+  Stdlib::Absolutepath           $path            = '/etc/systemd/network',
+  Optional[String]               $content         = undef,
+  Optional[String]               $source          = undef,
+  Optional[Stdlib::Absolutepath] $target          = undef,
+  String                         $owner           = 'root',
+  String                         $group           = 'root',
+  String                         $mode            = '0444',
+  Boolean                        $show_diff       = true,
+  Boolean                        $restart_service = true,
 ){
 
   include systemd
@@ -18,13 +22,14 @@ define systemd::network (
   }
 
   file { "${path}/${name}":
-    ensure  => $ensure,
-    content => $content,
-    source  => $source,
-    target  => $target,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0444',
-    notify  => $notify,
+    ensure    => $ensure,
+    content   => $content,
+    source    => $source,
+    target    => $target,
+    owner     => $owner,
+    group     => $group,
+    mode      => $mode,
+    show_diff => $show_diff,
+    notify    => $notify,
   }
 }

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -37,7 +37,7 @@
 #   The mode to set on the unit file
 #
 # @attr show_diff
-#   Wether to show the diff when updating unit file
+#   Whether to show the diff when updating unit file
 #
 # @attr enable
 #   If set, will manage the unit enablement status.

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -27,6 +27,18 @@
 #
 #   * Mutually exclusive with both ``$source`` and ``$content``
 #
+# @attr owner
+#   The owner to set on the unit file
+#
+# @attr group
+#   The group to set on the unit file
+#
+# @attr mode
+#   The mode to set on the unit file
+#
+# @attr show_diff
+#   Wether to show the diff when updating unit file
+#
 # @attr enable
 #   If set, will manage the unit enablement status.
 #
@@ -34,13 +46,17 @@
 #   If set, will manage the state of the unit.
 #
 define systemd::unit_file(
-  Enum['present', 'absent', 'file']        $ensure  = 'present',
-  Stdlib::Absolutepath                     $path    = '/etc/systemd/system',
-  Optional[String]                         $content = undef,
-  Optional[String]                         $source  = undef,
-  Optional[Stdlib::Absolutepath]           $target  = undef,
-  Optional[Variant[Boolean, Enum['mask']]] $enable  = undef,
-  Optional[Boolean]                        $active  = undef,
+  Enum['present', 'absent', 'file']        $ensure    = 'present',
+  Stdlib::Absolutepath                     $path      = '/etc/systemd/system',
+  Optional[String]                         $content   = undef,
+  Optional[String]                         $source    = undef,
+  Optional[Stdlib::Absolutepath]           $target    = undef,
+  String                                   $owner     = 'root',
+  String                                   $group     = 'root',
+  String                                   $mode      = '0444',
+  Boolean                                  $show_diff = true,
+  Optional[Variant[Boolean, Enum['mask']]] $enable    = undef,
+  Optional[Boolean]                        $active    = undef,
 ) {
   include systemd
 
@@ -56,14 +72,15 @@ define systemd::unit_file(
   }
 
   file { "${path}/${name}":
-    ensure  => $_ensure,
-    content => $content,
-    source  => $source,
-    target  => $target,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0444',
-    notify  => Class['systemd::systemctl::daemon_reload'],
+    ensure    => $_ensure,
+    content   => $content,
+    source    => $source,
+    target    => $target,
+    owner     => $owner,
+    group     => $group,
+    mode      => $mode,
+    show_diff => $show_diff,
+    notify    => Class['systemd::systemctl::daemon_reload'],
   }
 
   if $enable != undef or $active != undef {

--- a/spec/defines/network_spec.rb
+++ b/spec/defines/network_spec.rb
@@ -1,21 +1,59 @@
 require 'spec_helper'
 
 describe 'systemd::network' do
-  let :params do
-    {
-      restart_service: true
-    }
-  end
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        # manage systemd-networkd service
+        let :pre_condition do
+          "class { 'systemd':
+            manage_networkd => true,
+          }"
+        end
 
-  let(:title) { 'eth0.network' }
+        let(:facts) { facts }
 
-  on_supported_os.each do |os, facts|
-    let :facts do
-      facts
-    end
+        let(:title) { 'eth0.network' }
 
-    context 'with all defaults' do
-      it { is_expected.to compile.with_all_deps }
+        let(:params) {{
+          :content         => 'random stuff',
+          :restart_service => true,
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to create_file("/etc/systemd/network/#{title}").with(
+          :ensure  => 'file',
+          :content => /#{params[:content]}/,
+          :mode    => '0444'
+        ) }
+
+        it { is_expected.to create_file("/etc/systemd/network/#{title}").that_notifies('Service[systemd-networkd]') }
+
+        context 'with group => systemd-network, mode => 0640 and show_diff => false' do
+          let(:title) { 'wg0.netdev' }
+
+          let(:params) {{
+            :content         => 'secret string',
+            :group           => 'systemd-network',
+            :mode            => '0640',
+            :show_diff       => false,
+            :restart_service => true,
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to create_file("/etc/systemd/network/#{title}").with(
+            :ensure    => 'file',
+            :content   => /#{params[:content]}/,
+            :group     => 'systemd-network',
+            :mode      => '0640',
+            :show_diff => false
+          ) }
+
+          it { is_expected.to create_file("/etc/systemd/network/#{title}").that_notifies('Service[systemd-networkd]') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Some systemd files could contain sensitive information like .netdev
files associated with wireguard devices that contain private keys
and potentially pre-shared keys.