### PR TITLE
added function to returns a file system path as escaped by systemd

### DIFF
--- a/lib/puppet/parser/functions/systemd_escape.rb
+++ b/lib/puppet/parser/functions/systemd_escape.rb
@@ -1,0 +1,15 @@
+require 'puppet/util/execution'
+
+module Puppet::Parser::Functions
+  newfunction(:systemd_escape, :type => :rvalue, :doc => <<-EOS
+  Returns a file system path as escaped by systemd.
+  https://www.freedesktop.org/software/systemd/man/systemd.unit.html#String%20Escaping%20for%20Inclusion%20in%20Unit%20Names
+  EOS
+  ) do |args|
+    raise Puppet::ParseError, ("validate_cmd(): wrong number of arguments (#{args.length}; must be 1)") if args.length != 1
+    path = args[0]
+    cmd = "/bin/systemd-escape --path #{path}"
+    escaped = Puppet::Util::Execution.execute(cmd)
+    escaped.strip
+  end
+end


### PR DESCRIPTION
While creating a systemd mount and automount unit file, I needed a way to convert a mount point into a systemd unit name, as this requires some very specific conventions
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#String%20Escaping%20for%20Inclusion%20in%20Unit%20Names

Instead of recreating the logic in puppet, I've created a custom function that calls the native systemd-escape binary.

This can be used like this:
`$mount_name = systemd_escape($mountpoint)`
`systemd::unit_file { "${mount_name}.mount": }`