### PR TITLE
add missing systemd fact check for systemd::journald

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,7 @@ class systemd (
   if $manage_accounting {
     contain systemd::system
   }
-
-  contain systemd::journald
+  if $facts['systemd_internal_services'] {
+    contain systemd::journald
+  }
 }


### PR DESCRIPTION
Version 2.2.0 is no longer compatible with non-systemd systems. The addition of journald which I look forward to implementing for our farm does not have a check if the system has systemd.

This PR adds that check and makes the puppet-systemd module compatible again with non-systemd systems.