### PR TITLE
Allow `puppetlabs/inifile` 3.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 <3.0.0"
+      "version_requirement": ">= 1.6.0 <4.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
[`puppetlabs/inifile`](https://forge.puppet.com/puppetlabs/inifile) 3.0.0 was [recently](https://forge.puppet.com/puppetlabs/inifile/changelog) released.  It was a major version bump as they dropped support for puppet 4.