### PR TITLE
Allow `puppetlabs/stdlib` 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
stdlib 6.0.0 is due to be released soon.
This module does not use the updated `merge` function (which doesn't
work with puppet 4).

See
https://github.com/puppetlabs/puppetlabs-stdlib/blob/217068f97edd2396ce37ac8c1bd7e23da621d6be/CHANGELOG.md#supported-release-600
https://tickets.puppetlabs.com/browse/MODULES-9017