### PR TITLE
Remove stray `v` from Changelog `config.future_release`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     version = (Blacksmith::Modulefile.new).version
-    config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
+    config.future_release = version if version =~ /^\d+\.\d+.\d+$/
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
     config.user = 'camptocamp'


### PR DESCRIPTION
This project doesn't use a leading `v` on its git tags.