### PR TITLE
Allow for lazy/eager systemctl daemon reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ service {'foo':
 }
 ```
 
+Sometimes it's desirable to reload the systemctl daemon before a service is refreshed (for example:
+when overriding `ExecStart` or adding environment variables to the drop-in file).  In that case,
+use `daemon_reload => 'eager'` instead of the default `'lazy'`.  Be aware that the daemon could be
+reloaded multiple times if you have multiple `systemd::dropin_file` resources and any one of them
+is using `'eager'`.
+
 ### tmpfiles
 
 Let this module handle file creation and systemd reloading

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -39,18 +39,26 @@
 # @attr show_diff
 #   Whether to show the diff when updating dropin file
 #
+# @attr daemon_reload
+#   Set to `lazy` to defer execution of a systemctl daemon reload.
+#   Minimizes the number of times the daemon is reloaded.
+#   Set to `eager` to immediately reload after the dropin file is updated.
+#   Useful if the daemon needs to be reloaded before a service is refreshed.
+#   May cause multiple daemon reloads.
+#
 define systemd::dropin_file(
   Systemd::Unit                     $unit,
-  Systemd::Dropin                   $filename  = $name,
-  Enum['present', 'absent', 'file'] $ensure    = 'present',
-  Stdlib::Absolutepath              $path      = '/etc/systemd/system',
-  Optional[String]                  $content   = undef,
-  Optional[String]                  $source    = undef,
-  Optional[Stdlib::Absolutepath]    $target    = undef,
-  String                            $owner     = 'root',
-  String                            $group     = 'root',
-  String                            $mode      = '0444',
-  Boolean                           $show_diff = true,
+  Systemd::Dropin                   $filename      = $name,
+  Enum['present', 'absent', 'file'] $ensure        = 'present',
+  Stdlib::Absolutepath              $path          = '/etc/systemd/system',
+  Optional[String]                  $content       = undef,
+  Optional[String]                  $source        = undef,
+  Optional[Stdlib::Absolutepath]    $target        = undef,
+  String                            $owner         = 'root',
+  String                            $group         = 'root',
+  String                            $mode          = '0444',
+  Boolean                           $show_diff     = true,
+  Enum['lazy', 'eager']             $daemon_reload = 'lazy',
 ) {
   include systemd
 
@@ -82,6 +90,17 @@ define systemd::dropin_file(
     group     => $group,
     mode      => $mode,
     show_diff => $show_diff,
-    notify    => Class['systemd::systemctl::daemon_reload'],
+  }
+
+  if $daemon_reload == 'lazy' {
+    File["${path}/${unit}.d/${filename}"] ~> Class['systemd::systemctl::daemon_reload']
+  } else {
+    File["${path}/${unit}.d/${filename}"] ~> Exec["${unit}-systemctl-daemon-reload"]
+
+    exec { "${unit}-systemctl-daemon-reload":
+      command     => 'systemctl daemon-reload',
+      refreshonly => true,
+      path        => $facts['path'],
+    }
   }
 }

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -27,7 +27,21 @@ describe 'systemd::dropin_file' do
           :mode    => '0444'
         ) }
 
-        it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }
+        context 'with daemon_reload => lazy (default)' do
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }
+
+          it { is_expected.not_to create_exec("#{params[:unit]}-systemctl-daemon-reload") }
+        end
+
+        context 'with daemon_reload => eager' do
+          let(:params) do
+            super().merge({ :daemon_reload => 'eager' })
+          end
+
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies("Exec[#{params[:unit]}-systemctl-daemon-reload]") }
+
+          it { is_expected.to create_exec("#{params[:unit]}-systemctl-daemon-reload") }
+        end
 
         context 'with a bad unit type' do
           let(:title) { 'test.badtype' }


### PR DESCRIPTION
Add param for `systemd::dropin_file` to allow for `lazy` (the default behavior) or `eager` systemctl daemon reloading.

In some cases, the systemctl daemon should be reloaded before the related service is refreshed. For example, when overriding `ExecStart`. With the current behavior, it is impossible to do so if the `systemd::dropin_file` and related service are contained in the same class. There is also a potential for circular dependencies with multiple services that depend on each other and have multiple drop-in files associated with them.

The new lazy option emulates the current behavior, deferring the reload until (most likely) near the end of the Puppet run. It also has the advantage of only reloading the daemon once.

The eager option allows for the daemon to be reloaded immediately after changes to the specified drop-in file, at the cost of causing multiple reloads if there are multiple `systemd::dropin_file` resources.