### PR TITLE
Manage logind service and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,16 @@ systemd::network{'eth0.network':
 ### Services
 
 Systemd provides multiple services. Currently you can manage `systemd-resolved`,
-`systemd-timesyncd` and `systemd-networkd` via the main class:
+`systemd-timesyncd`, `systemd-networkd`, `systemd-journald` and `systemd-logind`
+via the main class:
 
 ```puppet
 class{'systemd':
   manage_resolved  => true,
   manage_networkd  => true,
   manage_timesyncd => true,
+  manage_journald  => true,
+  manage_logind    => true,
 }
 ```
 
@@ -225,4 +228,17 @@ systemd::journald_settings:
   MaxRetentionSec: 5day
   MaxLevelStore:
     ensure: absent
+```
+
+### logind configuration
+
+It also allows you to manage logind settings. You can manage logind settings through setting the `logind_settings` parameter. If you want a parameter to be removed, you can pass its value as params.
+
+```yaml
+systemd::logind_settings:
+  HandleSuspendKey: 'ignore'
+  KillUserProcesses: 'no'
+  RemoveIPC:
+    ensure: absent
+  UserTasksMax: 10000
 ```

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -23,3 +23,5 @@ systemd::accounting: {}
 systemd::purge_dropin_dirs: true
 systemd::manage_journald: true
 systemd::journald_settings: {}
+systemd::manage_logind: false
+systemd::logind_settings: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,12 @@
 # @param journald_settings
 #   Config Hash that is used to configure settings in journald.conf
 #
+# @param manage_logind
+#   Manage the systemd logind
+#
+# @param logind_settings
+#   Config Hash that is used to configure settings in logind.conf
+#
 class systemd (
   Hash[String,Hash[String, Any]]                         $service_limits,
   Boolean                                                $manage_resolved,
@@ -100,6 +106,8 @@ class systemd (
   Boolean                                                $purge_dropin_dirs,
   Boolean                                                $manage_journald,
   Systemd::JournaldSettings                              $journald_settings,
+  Boolean                                                $manage_logind,
+  Systemd::LogindSettings                                $logind_settings,
 ){
 
   contain systemd::systemctl::daemon_reload
@@ -124,5 +132,9 @@ class systemd (
 
   if $manage_journald {
     contain systemd::journald
+  }
+
+  if $manage_logind {
+    contain systemd::logind
   }
 }

--- a/manifests/logind.pp
+++ b/manifests/logind.pp
@@ -1,0 +1,31 @@
+# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
+#
+# This class manages systemd's login manager configuration.
+#
+# https://www.freedesktop.org/software/systemd/man/logind.conf.html
+class systemd::logind {
+
+  assert_private()
+
+  service{'systemd-logind':
+    ensure => running,
+  }
+  $systemd::logind_settings.each |$option, $value| {
+    ini_setting{
+      $option:
+        path    => '/etc/systemd/logind.conf',
+        section => 'Login',
+        setting => $option,
+        notify  => Service['systemd-logind'],
+    }
+    if $value =~ Hash {
+      Ini_setting[$option]{
+        * => $value,
+      }
+    } else {
+      Ini_setting[$option]{
+        value   => $value,
+      }
+    }
+  }
+}

--- a/manifests/logind.pp
+++ b/manifests/logind.pp
@@ -1,4 +1,4 @@
-# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
+# @api private
 #
 # This class manages systemd's login manager configuration.
 #

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -208,6 +208,51 @@ describe 'systemd' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_service('systemd-journald') }
         end
+
+        context 'when enabling logind with options' do
+          let(:params) do
+            {
+              :manage_logind   => true,
+              :logind_settings => {
+                'HandleSuspendKey'  => 'ignore',
+                'KillUserProcesses' => 'no',
+                'RemoveIPC'         => {
+                  'ensure' => 'absent',
+                },
+                'UserTasksMax'      => '10000',
+              }
+            }
+          end
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_service('systemd-logind').with(
+            :ensure => 'running'
+          ) }
+          it { is_expected.to have_ini_setting_resource_count(4) }
+          it { is_expected.to contain_ini_setting('HandleSuspendKey').with(
+            :path    => '/etc/systemd/logind.conf',
+            :section => 'Login',
+            :notify  => 'Service[systemd-logind]',
+            :value   => 'ignore',
+          )}
+          it { is_expected.to contain_ini_setting('KillUserProcesses').with(
+            :path    => '/etc/systemd/logind.conf',
+            :section => 'Login',
+            :notify  => 'Service[systemd-logind]',
+            :value   => 'no',
+          )}
+          it { is_expected.to contain_ini_setting('RemoveIPC').with(
+            :path    => '/etc/systemd/logind.conf',
+            :section => 'Login',
+            :notify  => 'Service[systemd-logind]',
+            :ensure  => 'absent',
+          )}
+          it { is_expected.to contain_ini_setting('UserTasksMax').with(
+            :path    => '/etc/systemd/logind.conf',
+            :section => 'Login',
+            :notify  => 'Service[systemd-logind]',
+            :value   => '10000',
+          )}
+        end
       end
     end
   end

--- a/types/logindsettings.pp
+++ b/types/logindsettings.pp
@@ -1,0 +1,29 @@
+# Matches Systemd Login Manager Struct
+type Systemd::LogindSettings = Struct[
+  {
+    Optional['HandleHibernateKey']           => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleLidSwitch']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleLidSwitchDocked']        => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleLidSwitchExternalPower'] => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandlePowerKey']               => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleSuspendKey']             => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HibernateKeyIgnoreInhibited']  => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['HoldoffTimeoutSec']            => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['IdleAction']                   => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['IdleActionSec']                => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['InhibitDelayMaxSec']           => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['InhibitorsMax']                => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['KillExcludeUsers']             => Variant[Array[String],Systemd::LogindSettings::Ensure],
+    Optional['KillOnlyUsers']                => Variant[Array[String],Systemd::LogindSettings::Ensure],
+    Optional['KillUserProcesses']            => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['LidSwitchIgnoreInhibited']     => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['NAutoVTs']                     => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['PowerKeyIgnoreInhibited']      => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['RemoveIPC']                    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['ReserveVT']                    => Variant[Integer,Systemd::LogindSettings::Ensure],
+    Optional['RuntimeDirectorySize']         => Variant[Integer,Pattern['^(\d+(K|M|G|T|P|E|%)?)$'],Systemd::LogindSettings::Ensure],
+    Optional['SessionsMax']                  => Variant[Integer,Pattern['^(infinity|(\d+(K|M|G|T|P|E|%)?))$'],Systemd::LogindSettings::Ensure],
+    Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['UserTasksMax']                 => Variant[Integer,Pattern['^(infinity|(\d+(K|M|G|T|P|E|%)?))$'],Systemd::LogindSettings::Ensure]
+  }
+]

--- a/types/logindsettings/ensure.pp
+++ b/types/logindsettings/ensure.pp
@@ -1,0 +1,1 @@
+type Systemd::LogindSettings::Ensure = Struct[{'ensure' => Enum['present','absent']}]


### PR DESCRIPTION
Make it possible to manage logind settings. Example configuration:

```
systemd::manage_logind: true

systemd::logind_settings:
  HandleSuspendKey: 'ignore'
  KillUserProcesses: 'no'
  RemoveIPC: 'no'
  UserTasksMax: 50000
```

This will allow me (and others) to migrate from https://github.com/NTTCom-MS/eyp-systemd to this module :)

This is (to some degree) a continuation of the discussion in https://github.com/voxpupuli/puppet-confluence/pull/173#issuecomment-468970053. Ping @bastelfreak.