### PR TITLE
add support for 'VirtuozzoLinux 7'

### DIFF
--- a/data/VirtuozzoLinux-7.yaml
+++ b/data/VirtuozzoLinux-7.yaml
@@ -1,0 +1,6 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -46,6 +46,12 @@
       ]
     },
     {
+      "operatingsystem": "VirtuozzoLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7"


### PR DESCRIPTION
`facter` 3.14 adds support for `os.name` *VirtuozzoLinux* (https://puppet.com/docs/puppet/latest/release_notes_facter.html). This means `os.name` won't resolve to *RedHat* anymore.