### PR TITLE
Correct order when ensuring unit files are absent

### DIFF
--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -4,45 +4,48 @@
 #
 # @see systemd.unit(5)
 #
-# @attr name [Pattern['^.+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
+# @param name [Pattern['^.+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
 #   The target unit file to create
 #
 #   * Must not contain ``/``
 #
-# @attr path
+# @param ensure
+#   The state of the unit file to ensure
+#
+# @param path
 #   The main systemd configuration path
 #
-# @attr content
+# @param content
 #   The full content of the unit file
 #
 #   * Mutually exclusive with ``$source``
 #
-# @attr source
+# @param source
 #   The ``File`` resource compatible ``source``
 #
 #   * Mutually exclusive with ``$content``
 #
-# @attr target
+# @param target
 #   If set, will force the file to be a symlink to the given target
 #
 #   * Mutually exclusive with both ``$source`` and ``$content``
 #
-# @attr owner
+# @param owner
 #   The owner to set on the unit file
 #
-# @attr group
+# @param group
 #   The group to set on the unit file
 #
-# @attr mode
+# @param mode
 #   The mode to set on the unit file
 #
-# @attr show_diff
+# @param show_diff
 #   Whether to show the diff when updating unit file
 #
-# @attr enable
+# @param enable
 #   If set, will manage the unit enablement status.
 #
-# @attr active
+# @param active
 #   If set, will manage the state of the unit.
 #
 define systemd::unit_file(

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -9,46 +9,42 @@ describe 'systemd::unit_file' do
         let(:title) { 'test.service' }
 
         let(:params) {{
-          :content => 'random stuff'
+          content: 'random stuff'
         }}
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to create_file("/etc/systemd/system/#{title}").with(
-          :ensure  => 'file',
-          :content => /#{params[:content]}/,
-          :mode    => '0444'
-        ) }
-
-        it { is_expected.to create_file("/etc/systemd/system/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }
+        it do
+          is_expected.to create_file("/etc/systemd/system/#{title}")
+            .with_ensure('file')
+            .with_content(/#{params[:content]}/)
+            .with_mode('0444')
+            .that_notifies('Class[systemd::systemctl::daemon_reload]')
+        end
 
         context 'with a bad unit type' do
           let(:title) { 'test.badtype' }
 
-          it {
-            expect{
-              is_expected.to compile.with_all_deps
-            }.to raise_error(/expects a match for Systemd::Unit/)
-          }
+          it { is_expected.to compile.and_raise_error(/expects a match for Systemd::Unit/) }
         end
 
         context 'with enable => true and active => true' do
           let(:params) do
-            super().merge({
-              :enable => true,
-              :active => true
-            })
+            super().merge(
+              enable: true,
+              active: true
+            )
           end
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_service('test.service').with(
-            :ensure   => true,
-            :enable   => true,
-            :provider => 'systemd'
-          ) }
-
-          it { is_expected.to contain_service('test.service').that_subscribes_to("File[/etc/systemd/system/#{title}]") }
-          it { is_expected.to contain_service('test.service').that_requires('Class[systemd::systemctl::daemon_reload]') }
+          it do
+            is_expected.to contain_service('test.service')
+							.with_ensure(true)
+							.with_enable(true)
+							.with_provider('systemd')
+							.that_subscribes_to("File[/etc/systemd/system/#{title}]")
+							.that_requires('Class[systemd::systemctl::daemon_reload]')
+          end
         end
 
         context 'ensure => absent' do


### PR DESCRIPTION
This ensures the service is stopped before the unit file is removed. Also does some other cleanups on the unit file.