### PR TITLE
Add OOMScoreAdjust to Systemd::ServiceLimits type

### DIFF
--- a/types/servicelimits.pp
+++ b/types/servicelimits.pp
@@ -39,6 +39,7 @@ type Systemd::ServiceLimits = Struct[
     Optional['DeviceAllow']         => String[1],
     Optional['DevicePolicy']        => Enum['auto','closed','strict'],
     Optional['Slice']               => String[1],
-    Optional['Delegate']            => Boolean
+    Optional['Delegate']            => Boolean,
+    Optional['OOMScoreAdjust']      => Integer[-1000,1000]
   }
 ]


### PR DESCRIPTION
As per [systemd.exec](https://www.freedesktop.org/software/systemd/man/systemd.exec.html), ```OOMScoreAdjust``` takes an integer between -1000 and 1000.