### PR TITLE
Force tmpfiles.d drop file to end in .conf

### DIFF
--- a/manifests/tmpfile.pp
+++ b/manifests/tmpfile.pp
@@ -4,10 +4,10 @@
 #
 # @see systemd-tmpfiles(8)
 #
-# @attr name [String]
+# @attr name [Pattern['^.+\.conf$']] (filename)
 #   The name of the tmpfile to create
 #
-#   * May not contain ``/``
+#   * May not contain ``/`` and must end in .conf
 #
 # @param $ensure
 #   Whether to drop a file or remove it
@@ -26,15 +26,16 @@
 #  * Mutually exclusive with ``$limits``
 #
 define systemd::tmpfile(
-  Enum['present', 'absent', 'file'] $ensure  = 'file',
-  Stdlib::Absolutepath              $path    = '/etc/tmpfiles.d',
-  Optional[String]                  $content = undef,
-  Optional[String]                  $source  = undef,
+  Enum['present', 'absent', 'file'] $ensure   = 'file',
+  Systemd::Dropin                   $filename = $name,
+  Stdlib::Absolutepath              $path     = '/etc/tmpfiles.d',
+  Optional[String]                  $content  = undef,
+  Optional[String]                  $source   = undef,
 ) {
   include systemd::tmpfiles
 
-  if $name =~ Pattern['/'] {
-    fail('$name may not contain a forward slash "(/)"')
+  if $filename =~ Pattern['/'] {
+    fail('$filename may not contain a forward slash "(/)"')
   }
 
   $_tmp_file_ensure = $ensure ? {
@@ -42,7 +43,7 @@ define systemd::tmpfile(
     default   => $ensure,
   }
 
-  file { "${path}/${name}":
+  file { "${path}/${filename}":
     ensure  => $_tmp_file_ensure,
     content => $content,
     source  => $source,

--- a/spec/defines/tmpfile_spec.rb
+++ b/spec/defines/tmpfile_spec.rb
@@ -6,7 +6,7 @@ describe 'systemd::tmpfile' do
       context "on #{os}" do
         let(:facts) { facts }
 
-        let(:title) { 'random_tmpfile' }
+        let(:title) { 'random_tmpfile.conf' }
 
         let(:params) {{
           :content => 'random stuff'
@@ -18,6 +18,29 @@ describe 'systemd::tmpfile' do
           :content => /#{params[:content]}/,
           :mode    => '0444'
         ) }
+
+        context 'with a bad tmpfile name' do
+          let(:title) { 'test.badtype' }
+          it {
+            expect{
+              is_expected.to compile.with_all_deps
+            }.to raise_error(/expects a match for Systemd::Dropin/)
+          }
+        end
+
+        context 'with a tmpfile name specified with filename' do
+          let(:title) { 'test.badtype' }
+          let(:params) {{
+            :filename => 'goodname.conf',
+            :content  => 'random stuff'
+          }}
+          it { is_expected.to create_file("/etc/tmpfiles.d/goodname.conf").with(
+            :ensure  => 'file',
+            :content => /#{params[:content]}/,
+            :mode    => '0444'
+          )}
+        end
+
       end
     end
   end


### PR DESCRIPTION
From tmpfiles.d(5)

```
SYNOPSIS
  /etc/tmpfiles.d/*.conf
  /run/tmpfiles.d/*.conf
  /usr/lib/tmpfiles.d/*.conf
```

Just like unit drop in files drop files for the tmpfiles.d must
end in .conf to be noticed.