### PR TITLE
Update types to avoid / in unit or drop file name

### DIFF
--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -4,10 +4,8 @@
 #
 # @see systemd.unit(5)
 #
-# @attr name [Pattern['^.+\.conf$']]
+# @attr name [Pattern['^[^/]+\.conf$']]
 #   The target unit file to create
-#
-#   * Must not contain ``/``
 #
 # @attr path
 #   The main systemd configuration path

--- a/manifests/tmpfile.pp
+++ b/manifests/tmpfile.pp
@@ -4,10 +4,8 @@
 #
 # @see systemd-tmpfiles(8)
 #
-# @attr name [Pattern['^.+\.conf$']] (filename)
+# @attr name [Pattern['^[^/]+\.conf$']] (filename)
 #   The name of the tmpfile to create
-#
-#   * May not contain ``/`` and must end in .conf
 #
 # @param $ensure
 #   Whether to drop a file or remove it
@@ -33,10 +31,6 @@ define systemd::tmpfile(
   Optional[String]                  $source   = undef,
 ) {
   include systemd::tmpfiles
-
-  if $filename =~ Pattern['/'] {
-    fail('$filename may not contain a forward slash "(/)"')
-  }
 
   $_tmp_file_ensure = $ensure ? {
     'present' => 'file',

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -4,10 +4,8 @@
 #
 # @see systemd.unit(5)
 #
-# @param name [Pattern['^.+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
+# @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
 #   The target unit file to create
-#
-#   * Must not contain ``/``
 #
 # @param ensure
 #   The state of the unit file to ensure

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -53,6 +53,17 @@ describe 'systemd::dropin_file' do
           }
         end
 
+        context 'with a bad unit type containing a slash' do
+          let(:title) { 'test/bad.conf' }
+
+          it {
+            expect{
+              is_expected.to compile.with_all_deps
+            }.to raise_error(/expects a match for Systemd::Dropin/)
+          }
+        end
+
+
         context 'with another drop-in file with the same filename (and content)' do
           let(:default_params) {{
             :filename => 'longer-timeout.conf',

--- a/spec/defines/tmpfile_spec.rb
+++ b/spec/defines/tmpfile_spec.rb
@@ -28,6 +28,16 @@ describe 'systemd::tmpfile' do
           }
         end
 
+        context 'with a bad tmpfile name with slash' do
+          let(:title) { 'test/foo.conf' }
+          it {
+            expect{
+              is_expected.to compile.with_all_deps
+            }.to raise_error(/expects a match for Systemd::Dropin/)
+          }
+        end
+
+
         context 'with a tmpfile name specified with filename' do
           let(:title) { 'test.badtype' }
           let(:params) {{

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -28,6 +28,12 @@ describe 'systemd::unit_file' do
           it { is_expected.to compile.and_raise_error(/expects a match for Systemd::Unit/) }
         end
 
+        context 'with a bad unit type containing a slash' do
+          let(:title) { 'test/unit.service' }
+
+          it { is_expected.to compile.and_raise_error(/expects a match for Systemd::Unit/) }
+        end
+
         context 'with enable => true and active => true' do
           let(:params) do
             super().merge(

--- a/types/dropin.pp
+++ b/types/dropin.pp
@@ -1,1 +1,1 @@
-type Systemd::Dropin = Pattern['^.+\.conf$']
+type Systemd::Dropin = Pattern['^[^/]+\.conf$']

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,1 +1,1 @@
-type Systemd::Unit = Pattern['^.+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']
+type Systemd::Unit = Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']


### PR DESCRIPTION
The assertion that unit names and drop files names do not
contain a `/` is now done with in the Systemd::Dropin
and `Systemd::Unit` types.

Peviously the assertion was done either within code or just via docs.