### PR TITLE
Add SLES 12/15 support

### DIFF
--- a/data/SLES-12.yaml
+++ b/data/SLES-12.yaml
@@ -1,0 +1,6 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'

--- a/data/SLES-15.yaml
+++ b/data/SLES-15.yaml
@@ -1,0 +1,6 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,13 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12",
+        "15"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7"

--- a/spec/acceptance/nodesets/opensuse-15.1.yml
+++ b/spec/acceptance/nodesets/opensuse-15.1.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  opensuse-15-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: opensuse-15-amd64
+    hypervisor : docker
+    image: opensuse/leap:15
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'zypper install -y cronie tar wget iproute2'
+CONFIG:
+  type: foss
+  log_level: debug

--- a/spec/acceptance/nodesets/opensuse-15.2.yml
+++ b/spec/acceptance/nodesets/opensuse-15.2.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  opensuse-15-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: opensuse-15-amd64
+    hypervisor : docker
+    image: opensuse/leap:15
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'zypper install -y cronie tar wget iproute2'
+CONFIG:
+  type: foss
+  log_level: debug

--- a/spec/acceptance/nodesets/opensuse-15.yml
+++ b/spec/acceptance/nodesets/opensuse-15.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  opensuse-15-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: opensuse-15-amd64
+    hypervisor : docker
+    image: opensuse/leap:15
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'zypper install -y cronie tar wget iproute2'
+CONFIG:
+  type: foss
+  log_level: debug

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -173,6 +173,8 @@ describe 'systemd' do
             accounting = ['DefaultCPUAccounting', 'DefaultBlockIOAccounting', 'DefaultMemoryAccounting']
           when 'RedHat'
             accounting = ['DefaultCPUAccounting', 'DefaultBlockIOAccounting', 'DefaultMemoryAccounting', 'DefaultTasksAccounting']
+          when 'Suse'
+            accounting = ['DefaultCPUAccounting', 'DefaultBlockIOAccounting', 'DefaultMemoryAccounting', 'DefaultTasksAccounting']
           end
           accounting.each do |account|
             it { is_expected.to contain_ini_setting(account) }


### PR DESCRIPTION
I used OpenSUSE docker images in the acceptance test areas as that is what is available on the Docker Hub. They should be a good approximation, however.