### PR TITLE
Use Storage parameter of $systemd::journald_settings to handle storage

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,7 +109,6 @@ class systemd (
   Boolean                                                $purge_dropin_dirs,
   Boolean                                                $manage_journald,
   Systemd::JournaldSettings                              $journald_settings,
-  Boolean                                                $journald_persist_log,
   Boolean                                                $manage_logind,
   Systemd::LogindSettings                                $logind_settings,
 ){

--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -6,19 +6,15 @@
 class systemd::journald {
 
   assert_private()
-
-  if $systemd::journald_persist_log {
-    $journald_dir = 'directory'
-  } else {
-    $journald_dir = 'absent'
-  }
-
-  file { '/var/log/journal':
-    ensure => $journald_dir,
-    force  => true,
-    owner  => 'root',
-    group  => 'systemd-journal',
-    mode   => '2755',
+  if 'Storage' in $systemd::journald_settings {
+    if $systemd::journald_settings['Storage'] == 'persistent' {
+      file { '/var/log/journal':
+        ensure => 'directory',
+        owner  => 'root',
+        group  => 'systemd-journal',
+        mode   => '2755',
+      }
+    }
   }
 
   service{'systemd-journald':

--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -6,14 +6,13 @@
 class systemd::journald {
 
   assert_private()
-  if 'Storage' in $systemd::journald_settings {
-    if $systemd::journald_settings['Storage'] == 'persistent' {
-      file { '/var/log/journal':
-        ensure => 'directory',
-        owner  => 'root',
-        group  => 'systemd-journal',
-        mode   => '2755',
-      }
+
+  if $systemd::journald_settings['Storage'] == 'auto' {
+    file { '/var/log/journal':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'systemd-journal',
+      mode   => '2755',
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -239,10 +239,13 @@ describe 'systemd' do
           it { is_expected.not_to contain_service('systemd-journald') }
         end
 
-        context 'when enabling journald log persistence' do
+        context 'when you want to keep your logs' do
           let(:params) do
             {
-              journald_persist_log: true,
+              journald_settings:
+              {
+                Storage: 'auto',
+              },
             }
           end
 
@@ -257,19 +260,9 @@ describe 'systemd' do
           }
         end
 
-        context 'when disabling journald log persistence' do
-          let(:params) do
-            {
-              journald_persist_log: false,
-            }
-          end
-
+        context 'without parameters' do
           it { is_expected.to compile.with_all_deps }
-          it {
-            is_expected.to contain_file('/var/log/journal').with(
-              ensure: 'absent',
-            )
-          }
+          it { is_expected.not_to contain_file('/var/log/journal') }
         end
 
         context 'when enabling logind with options' do


### PR DESCRIPTION
Following up on  #127 

It does not look needed to add a new parameter for journald persistend, when this is actually handled by $systemd::journald_settings in the key 'Storage'.

Also, creation of the folder should be done only if Storage=auto , otherwise this is handled by journald itself (as per man page)