### PR TITLE
Only do daemon reloads on Puppet 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Create a systemd timer unit and a systemd service unit to execute from
 that timer
 
 The following will create a timer unit and a service unit file.
-The execution of `systemctl daemon-reload` will occur.
+The execution of `systemctl daemon-reload` will occur in Puppet < 6.1. Puppet >= 6.1 handles this itself.
 When `active` and `enable` are set to `true` the puppet service `runoften.timer` will be
 declared, started and enabled.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,8 +112,7 @@ class systemd (
   Systemd::LogindSettings                                $logind_settings,
   Hash                                                   $dropin_files = {},
 ){
-
-  contain systemd::systemctl::daemon_reload
+  $manage_daemon_reload = versioncmp($facts['puppetversion'], '6.1.0') < 0
 
   create_resources('systemd::service_limits', $service_limits)
 

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -76,7 +76,10 @@ define systemd::service_limits(
       path        => $::path,
       refreshonly => true,
       subscribe   => File["${path}/${name}.d/90-limits.conf"],
-      require     => Class['systemd::systemctl::daemon_reload'],
+    }
+
+    if $systemd::manage_daemon_reload {
+      Exec["restart ${name} because limits"] ~> Class['systemd::systemctl::daemon_reload']
     }
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -13,7 +13,10 @@ class systemd::system {
       section => 'Manager',
       setting => $option,
       value   => $value,
-      notify  => Class['systemd::systemctl::daemon_reload'],
+    }
+
+    if $systemd::manage_daemon_reload {
+      Ini_setting[$option] ~>Class['systemd::systemctl::daemon_reload']
     }
   }
 }

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -81,7 +81,10 @@ define systemd::unit_file(
     group     => $group,
     mode      => $mode,
     show_diff => $show_diff,
-    notify    => Class['systemd::systemctl::daemon_reload'],
+  }
+
+  if $systemd::manage_daemon_reload {
+    File["${path}/${name}"] ~> Class['systemd::systemctl::daemon_reload']
   }
 
   if $enable != undef or $active != undef {
@@ -97,7 +100,9 @@ define systemd::unit_file(
       }
       Service[$name] -> File["${path}/${name}"]
     } else {
-      Class['systemd::systemctl::daemon_reload'] -> Service[$name]
+      if $systemd::manage_daemon_reload {
+        Class['systemd::systemctl::daemon_reload'] -> Service[$name]
+      }
       File["${path}/${name}"] ~> Service[$name]
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,13 @@ describe 'systemd' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('systemd') }
-        it { is_expected.to create_class('systemd::systemctl::daemon_reload') }
+        it do
+          if facts[:puppetversion] >= '6.1'
+            is_expected.not_to create_class('systemd::systemctl::daemon_reload')
+          else
+            is_expected.to create_class('systemd::systemctl::daemon_reload')
+          end
+        end
         it { is_expected.to contain_class('systemd::journald') }
         it { is_expected.to create_service('systemd-journald') }
         it { is_expected.to have_ini_setting_resource_count(0) }

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -15,7 +15,16 @@ describe 'systemd::unit_file' do
             .with_ensure('file')
             .with_content(%r{#{params[:content]}})
             .with_mode('0444')
-            .that_notifies('Class[systemd::systemctl::daemon_reload]')
+        end
+
+        it do
+          if facts[:puppetversion] >= '6.1'
+            is_expected.not_to create_file("/etc/systemd/system/#{title}")
+              .that_notifies('Class[systemd::systemctl::daemon_reload]')
+          else
+            is_expected.to create_file("/etc/systemd/system/#{title}")
+              .that_notifies('Class[systemd::systemctl::daemon_reload]')
+          end
         end
 
         context 'with a bad unit type' do
@@ -45,7 +54,16 @@ describe 'systemd::unit_file' do
               .with_enable(true)
               .with_provider('systemd')
               .that_subscribes_to("File[/etc/systemd/system/#{title}]")
-              .that_requires('Class[systemd::systemctl::daemon_reload]')
+          end
+
+          it do
+            if facts[:puppetversion] >= '6.1'
+              is_expected.not_to contain_service('test.service')
+                .that_requires('Class[systemd::systemctl::daemon_reload]')
+            else
+              is_expected.to contain_service('test.service')
+                .that_requires('Class[systemd::systemctl::daemon_reload]')
+            end
           end
         end
 


### PR DESCRIPTION
Puppet 6.1 contains [PUP-3483](https://tickets.puppetlabs.com/browse/PUP-3483) which means daemon reloads are not needed.

This is useful because the systemd daemon reloads can easily trigger dependency cycles. For example, managing service x and y where y depends on x.