### PR TITLE
Add selinux_ignore_defaults support to dropin_file and service_limits

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -13,6 +13,9 @@
 # @param path
 #   The path to the main systemd settings directory
 #
+# @param selinux_ignore_defaults
+#   If Puppet should ignore the default SELinux labels.
+#
 # @param limits
 #   A Hash of service limits matching the settings in ``systemd.exec(5)``
 #
@@ -27,11 +30,12 @@
 #   Restart the managed service after setting the limits
 #
 define systemd::service_limits(
-  Enum['present', 'absent', 'file'] $ensure          = 'present',
-  Stdlib::Absolutepath              $path            = '/etc/systemd/system',
-  Optional[Systemd::ServiceLimits]  $limits          = undef,
-  Optional[String]                  $source          = undef,
-  Boolean                           $restart_service = true
+  Enum['present', 'absent', 'file'] $ensure                  = 'present',
+  Stdlib::Absolutepath              $path                    = '/etc/systemd/system',
+  Optional[Boolean]                 $selinux_ignore_defaults = false,
+  Optional[Systemd::ServiceLimits]  $limits                  = undef,
+  Optional[String]                  $source                  = undef,
+  Boolean                           $restart_service         = true
 ) {
 
   include systemd
@@ -57,12 +61,13 @@ define systemd::service_limits(
   }
 
   systemd::dropin_file { "${name}-90-limits.conf":
-    ensure   => $ensure,
-    unit     => $name,
-    filename => '90-limits.conf',
-    path     => $path,
-    content  => $_content,
-    source   => $source,
+    ensure                  => $ensure,
+    unit                    => $name,
+    filename                => '90-limits.conf',
+    path                    => $path,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    content                 => $_content,
+    source                  => $source,
   }
 
   if $restart_service {

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -22,6 +22,7 @@ describe 'systemd::dropin_file' do
             ensure: 'directory',
             recurse: 'true',
             purge: 'true',
+            selinux_ignore_defaults: false,
           )
         }
 
@@ -30,8 +31,18 @@ describe 'systemd::dropin_file' do
             ensure: 'file',
             content: %r{#{params[:content]}},
             mode: '0444',
+            selinux_ignore_defaults: false,
           )
         }
+
+        context 'with selinux_ignore_defaults set to true' do
+          let(:params) do
+            super().merge(selinux_ignore_defaults: true)
+          end
+
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d").with_selinux_ignore_defaults(true) }
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").with_selinux_ignore_defaults(true) }
+        end
 
         context 'with daemon_reload => lazy (default)' do
           it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }


### PR DESCRIPTION
This commits add support for passing the service_ignore_defaults parameter to the file resources being handled in the dropin_file definition. It then adds the parameter to service_limits which use dropin_file so that consumers of this resource can pass it.

This is needed in order to support RHEL based operating systems again in puppet-rabbitmq module where the Puppet run is idempotent after moving to the systemd module [1].

[1] https://github.com/voxpupuli/puppet-rabbitmq/issues/836