### PR TITLE
Fix typo in parameter name in class documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@
 # @param logind_settings
 #   Config Hash that is used to configure settings in logind.conf
 #
-# @param drpoin_files
+# @param dropin_files
 #   Configure dropin files via hiera with factory pattern
 class systemd (
   Hash[String,Hash[String, Any]]                         $service_limits,


### PR DESCRIPTION
90cc85cbccc00cc51b775639eb9c20293446e63e introduced this but with a typo in the
name so puppet-strings couldn't find it.