### PR TITLE
Convert from mocha to rspec-mocks

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -14,3 +14,5 @@ Gemfile:
       - gem: 'github_changelog_generator'
 Rakefile:
   changelog_version_tag_pattern: '%s'
+spec/spec_helper.rb:
+  mock_with: :rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -5,8 +5,6 @@ add_custom_fact :systemd_internal_services, YAML.safe_load(File.read(File.expand
 RSpec::Mocks::Syntax.enable_expect(RSpec::Puppet::ManifestMatchers)
 
 RSpec.configure do |config|
-  config.mock_with :rspec
-
   config.before :each do
     # Ensure that we don't accidentally cache facts and environment between
     # test cases.  This requires each example group to explicitly load the

--- a/spec/unit/facter/systemd_spec.rb
+++ b/spec/unit/facter/systemd_spec.rb
@@ -7,7 +7,7 @@ describe Facter.fact(:systemd) do
   describe 'systemd' do
     context 'returns true when systemd present' do
       before(:each) do
-        Facter.fact(:kernel).stubs(:value).returns(:linux)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return(:linux)
         Facter.add(:service_provider) { setcode { 'systemd' } }
       end
 
@@ -17,7 +17,7 @@ describe Facter.fact(:systemd) do
 
     context 'returns false when systemd not present' do
       before(:each) do
-        Facter.fact(:kernel).stubs(:value).returns(:linux)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return(:linux)
         Facter.add(:service_provider) { setcode { 'redhat' } }
       end
 
@@ -27,7 +27,7 @@ describe Facter.fact(:systemd) do
 
     context 'returns nil when kernel is not linux' do
       before(:each) do
-        Facter.fact(:kernel).stubs(:value).returns(:windows)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return(:windows)
       end
 
       it { expect(Facter.value(:systemd)).to be_nil }

--- a/spec/unit/facter/systemd_version_spec.rb
+++ b/spec/unit/facter/systemd_version_spec.rb
@@ -8,24 +8,23 @@ describe Facter.fact(:systemd_version) do
   describe 'systemd_version' do
     context 'returns version when systemd fact present' do
       before(:each) do
-        Facter.fact(:systemd).stubs(:value).returns(true)
+        allow(Facter.fact(:systemd)).to receive(:value).and_return(true)
       end
       let(:facts) { { systemd: true } }
 
       it do
-        Facter::Util::Resolution.expects(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").returns('229')
+        expect(Facter::Util::Resolution).to receive(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").and_return('229')
         expect(Facter.value(:systemd_version)).to eq('229')
       end
     end
     context 'returns nil when systemd fact not present' do
       before(:each) do
-        Facter.fact(:systemd).stubs(:value).returns(false)
+        allow(Facter.fact(:systemd)).to receive(:value).and_return(false)
       end
       let(:facts) { { systemd: false } }
 
       it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").never
+        expect(Facter::Util::Resolution).not_to receive(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'")
         expect(Facter.value(:systemd_version)).to eq(nil)
       end
     end


### PR DESCRIPTION
This is recommended by puppetlabs_spec_helper and avoids a deprecation warning.