### PR TITLE
Add parameter for ENCs to make loginctl_users easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,3 +342,5 @@ loginctl_user { 'foo':
   linger => enabled,
 }
 ```
+
+or as a hash via the `systemd::loginctl_users` parameter.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,10 @@
 # @param logind_settings
 #   Config Hash that is used to configure settings in logind.conf
 #
+# @param loginctl_users
+#   Config Hash that is used to generate instances of our type
+#   `loginctl_user`.
+#
 # @param dropin_files
 #   Configure dropin files via hiera with factory pattern
 class systemd (
@@ -110,6 +114,7 @@ class systemd (
   Systemd::JournaldSettings                              $journald_settings,
   Boolean                                                $manage_logind,
   Systemd::LogindSettings                                $logind_settings,
+  Hash                                                   $loginctl_users = {},
   Hash                                                   $dropin_files = {},
 ) {
   contain systemd::systemctl::daemon_reload

--- a/manifests/logind.pp
+++ b/manifests/logind.pp
@@ -27,4 +27,10 @@ class systemd::logind {
       }
     }
   }
+
+  $systemd::loginctl_users.each |$loginctl_name, $loginctl_settings| {
+    loginctl_user { $loginctl_name:
+      * => $loginctl_settings,
+    }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -296,7 +296,7 @@ describe 'systemd' do
               value: '10000',
             )
           }
-          it { is_expected.to have__loginctl_user('foo').with(linger: 'enabled') }
+          it { is_expected.to contain_loginctl_user('foo').with(linger: 'enabled') }
         end
         context 'when passing dropin_files' do
           let(:params) do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -251,6 +251,9 @@ describe 'systemd' do
                 },
                 'UserTasksMax' => '10000',
               },
+              loginctl_users: {
+                'foo' => { 'linger' => 'enabled' },
+              },
             }
           end
 
@@ -293,6 +296,7 @@ describe 'systemd' do
               value: '10000',
             )
           }
+          it { is_expected.to have__loginctl_user('foo').with(linger: 'enabled') }
         end
         context 'when passing dropin_files' do
           let(:params) do


### PR DESCRIPTION
This should make it much easier to build `loginctl_users` for folks running with an ENC.