### PR TITLE
Permit using arrays to make extending lists easier

### DIFF
--- a/manifests/logind.pp
+++ b/manifests/logind.pp
@@ -21,6 +21,10 @@ class systemd::logind {
       Ini_setting[$option] {
         * => $value,
       }
+    } elsif $value =~ Array {
+      Ini_setting[$option] {
+        value   => join($value, ' '),
+      }
     } else {
       Ini_setting[$option] {
         value   => $value,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -246,6 +246,7 @@ describe 'systemd' do
               logind_settings: {
                 'HandleSuspendKey'  => 'ignore',
                 'KillUserProcesses' => 'no',
+                'KillExcludeUsers'  => ['a', 'b'],
                 'RemoveIPC'         => {
                   'ensure' => 'absent',
                 },
@@ -260,7 +261,7 @@ describe 'systemd' do
               ensure: 'running',
             )
           }
-          it { is_expected.to have_ini_setting_resource_count(4) }
+          it { is_expected.to have_ini_setting_resource_count(5) }
           it {
             is_expected.to contain_ini_setting('HandleSuspendKey').with(
               path: '/etc/systemd/logind.conf',
@@ -275,6 +276,14 @@ describe 'systemd' do
               section: 'Login',
               notify: 'Service[systemd-logind]',
               value: 'no',
+            )
+          }
+          it {
+            is_expected.to contain_ini_setting('KillExcludeUsers').with(
+              path: '/etc/systemd/logind.conf',
+              section: 'Login',
+              notify: 'Service[systemd-logind]',
+              value: 'a b',
             )
           }
           it {


### PR DESCRIPTION
For the loginctl user parameter lists, it is easier to set them as an array (that way I can append or de-dupe easily).

Psudo hiera:

```yaml
systemd::logind_settings:
  KillExcludeUsers: 
  - root
```

```yaml
systemd::logind_settings:
  KillExcludeUsers: 
  - other_user
```