### PR TITLE
Add management of udev objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ class{'systemd':
   manage_networkd  => true,
   manage_timesyncd => true,
   manage_journald  => true,
+  manage_udevd     => true,
   manage_logind    => true,
 }
 ```
@@ -318,6 +319,41 @@ systemd::journald_settings:
   MaxRetentionSec: 5day
   MaxLevelStore:
     ensure: absent
+```
+
+### udevd configuration
+
+It allows you to manage the udevd configuration.  You can set the udev.conf values via the `udev_log`, `udev_children_max`, `udev_exec_delay`, `udev_event_timeout`, `udev_resolve_names`, and `udev_timeout_signal` parameters.
+
+Additionally you can set custom udev rules with the `udev_rules` parameter.
+
+```puppet
+class { 'systemd':
+  manage_udevd => true,
+  udev_rules   => { 
+      'example_raw.rules' => {
+      'rules'             => [
+        'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
+        'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+      ],
+    },
+  },
+}
+```
+
+### udev::rules configuration
+
+Custom udev rules can be defined for specific events.
+
+```yaml
+systemd::udev::rule:
+  ensure: present
+  path: /etc/udev/rules.d
+  selinux_ignore_defaults: false
+  notify: "Service[systemd-udevd']"
+  rules:
+    - 'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"'
+    - 'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
 ```
 
 ### logind configuration

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -23,5 +23,12 @@ systemd::accounting: {}
 systemd::purge_dropin_dirs: true
 systemd::manage_journald: true
 systemd::journald_settings: {}
+systemd::manage_udevd: false
+systemd::udev_log: ~
+systemd::udev_children_max: ~
+systemd::udev_exec_delay: ~
+systemd::udev_event_timeout: ~
+systemd::udev_timeout_signal: ~
+systemd::udev_resolve_names: ~
 systemd::manage_logind: false
 systemd::logind_settings: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,31 @@
 # @param journald_settings
 #   Config Hash that is used to configure settings in journald.conf
 #
+# @param manage_udevd
+#   Manage the systemd udev daemon
+#
+# @param udev_log
+#   The value of /etc/udev/udev.conf udev_log
+#
+# @param udev_children_max
+#   The value of /etc/udev/udev.conf children_max
+#
+# @param udev_exec_delay
+#   The value of /etc/udev/udev.conf exec_delay
+#
+# @param udev_event_timeout
+#   The value of /etc/udev/udev.conf event_timeout
+#
+# @param udev_resolve_names
+#   The value of /etc/udev/udev.conf resolve_names
+#
+# @param udev_timeout_signal
+#   The value of /etc/udev/udev.conf timeout_signal
+#
+# @param udev_rules
+#   Config Hash that is used to generate instances of our
+#   `udev::rule` define.
+#
 # @param manage_logind
 #   Manage the systemd logind
 #
@@ -112,10 +137,18 @@ class systemd (
   Boolean                                                $purge_dropin_dirs,
   Boolean                                                $manage_journald,
   Systemd::JournaldSettings                              $journald_settings,
+  Boolean                                                $manage_udevd,
+  Optional[Variant[Integer,String]]                      $udev_log,
+  Optional[Integer]                                      $udev_children_max,
+  Optional[Integer]                                      $udev_exec_delay,
+  Optional[Integer]                                      $udev_event_timeout,
+  Optional[Enum['early', 'late', 'never']]               $udev_resolve_names,
+  Optional[Variant[Integer,String]]                      $udev_timeout_signal,
   Boolean                                                $manage_logind,
   Systemd::LogindSettings                                $logind_settings,
   Hash                                                   $loginctl_users = {},
   Hash                                                   $dropin_files = {},
+  Hash                                                   $udev_rules = {},
 ) {
   contain systemd::systemctl::daemon_reload
 
@@ -131,6 +164,10 @@ class systemd (
 
   if $manage_timesyncd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-timesyncd.service'] {
     contain systemd::timesyncd
+  }
+
+  if $manage_udevd {
+    contain systemd::udevd
   }
 
   if $manage_accounting {

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -1,0 +1,48 @@
+# Adds a custom udev rule
+#
+# @api public
+#
+# @see udev(7)
+#
+# @attr name [Pattern['^.+\.rules$']]
+#   The name of the udev rules to create
+#
+# @param $ensure
+#   Whether to drop a file or remove it
+#
+# @param path
+#   The path to the main systemd settings directory
+#
+# @param selinux_ignore_defaults
+#   If Puppet should ignore the default SELinux labels.
+#
+# @param notify_services
+#   List of services to notify when this rule is updated
+#
+# @param rules
+#   The literal udev rules you want to deploy
+#
+define systemd::udev::rule (
+  Array                             $rules,
+  Enum['present', 'absent', 'file'] $ensure                  = 'present',
+  Stdlib::Absolutepath              $path                    = '/etc/udev/rules.d',
+  Optional[Variant[Array, String]]  $notify_services         = [],
+  Optional[Boolean]                 $selinux_ignore_defaults = false,
+) {
+  include systemd
+
+  $filename = assert_type(Pattern['^.+\.rules$'], $name) |$expected, $actual| {
+    fail("The \$name should match \'${expected}\', you passed \'${actual}\'")
+  }
+
+  file { $filename:
+    ensure                  => $ensure,
+    owner                   => 'root',
+    group                   => 'root',
+    mode                    => '0444',
+    path                    => join([$path, $name], '/'),
+    notify                  => $notify_services,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    content                 => epp("${module_name}/udev_rule.epp", {'rules' => $rules}),
+  }
+}

--- a/manifests/udevd.pp
+++ b/manifests/udevd.pp
@@ -1,0 +1,35 @@
+# @api private
+#
+# This class manages systemd's udev config
+#
+# https://www.freedesktop.org/software/systemd/man/udev.conf.html
+class systemd::udevd {
+  assert_private()
+
+  service { 'systemd-udevd':
+    ensure => running,
+    enable => true,
+  }
+
+  file { '/etc/udev/udev.conf':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => epp("${module_name}/udev_conf.epp", {
+        'udev_log'            => $systemd::udev_log,
+        'udev_children_max'   => $systemd::udev_children_max,
+        'udev_exec_delay'     => $systemd::udev_exec_delay,
+        'udev_event_timeout'  => $systemd::udev_event_timeout,
+        'udev_resolve_names'  => $systemd::udev_resolve_names,
+        'udev_timeout_signal' => $systemd::udev_timeout_signal,
+    }),
+    notify  => Service['systemd-udevd'],
+  }
+
+  $systemd::udev_rules.each |$udev_rule_name, $udev_rule| {
+    systemd::udev::rule { $udev_rule_name:
+      * => $udev_rule,
+    }
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -239,6 +239,102 @@ describe 'systemd' do
           it { is_expected.not_to contain_service('systemd-journald') }
         end
 
+        context 'when disabling udevd management' do
+          let(:params) do
+            {
+              manage_udevd: false,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_service('systemd-udevd') }
+          it { is_expected.not_to contain_file('/etc/udev/udev.conf') }
+        end
+
+        context 'when working with udevd and no custom rules' do
+          let(:params) do
+            {
+              manage_udevd: true,
+              udev_log: 'daemon',
+              udev_children_max: 1,
+              udev_exec_delay: 2,
+              udev_event_timeout: 3,
+              udev_resolve_names: 'early',
+              udev_timeout_signal: 'SIGKILL',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_service('systemd-udevd')
+              .with(enable: true,
+                    ensure: 'running')
+          }
+          it {
+            is_expected.to contain_file('/etc/udev/udev.conf')
+              .with(ensure: 'file',
+                    owner: 'root',
+                    group: 'root',
+                    mode: '0444')
+              .with_content(%r{^udev_log=daemon$})
+              .with_content(%r{^children_max=1$})
+              .with_content(%r{^exec_delay=2$})
+              .with_content(%r{^event_timeout=3$})
+              .with_content(%r{^resolve_names=early$})
+              .with_content(%r{^timeout_signal=SIGKILL$})
+          }
+        end
+
+        context 'when working with udevd and a rule set' do
+          let(:params) do
+            {
+              manage_udevd: true,
+              udev_log: 'daemon',
+              udev_children_max: 1,
+              udev_exec_delay: 2,
+              udev_event_timeout: 3,
+              udev_resolve_names: 'early',
+              udev_timeout_signal: 'SIGKILL',
+              udev_rules: { 'example_raw.rules' => {
+                'rules' => [
+                  '# I am a comment',
+                  'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
+                  'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+                ],
+              } },
+
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_service('systemd-udevd')
+              .with(enable: true,
+                    ensure: 'running')
+          }
+          it {
+            is_expected.to contain_file('/etc/udev/udev.conf')
+              .with(ensure: 'file',
+                    owner: 'root',
+                    group: 'root',
+                    mode: '0444')
+              .with_content(%r{^udev_log=daemon$})
+              .with_content(%r{^children_max=1$})
+              .with_content(%r{^exec_delay=2$})
+              .with_content(%r{^event_timeout=3$})
+              .with_content(%r{^resolve_names=early$})
+              .with_content(%r{^timeout_signal=SIGKILL$})
+          }
+          it {
+            is_expected.to contain_systemd__udev__rule('example_raw.rules')
+              .with(rules: [
+                      '# I am a comment',
+                      'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
+                      'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+                    ])
+          }
+        end
+
         context 'when enabling logind with options' do
           let(:params) do
             {

--- a/spec/defines/udev_rules.spec
+++ b/spec/defines/udev_rules.spec
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe 'systemd::udev::rule' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        let(:title) { 'test.rules' }
+
+        describe 'with all options (one notify)' do
+          let(:params) do
+            {
+              ensure: 'present',
+              path: '/etc/udev/rules.d',
+              selinux_ignore_defaults: false,
+              notify_services: "Service['systemd-udevd']",
+              rules: [
+                '# I am a comment',
+                'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
+                'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+              ],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to create_file("/etc/udev/rules.d/#{title}")
+              .with(ensure: 'file', mode: '0444', owner: 'root', group: 'root')
+              .with_content(%r{^# I am a comment$})
+              .with_content(%r{^ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"$})
+              .with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"$})
+              .that_notifies("Service['systemd-udevd']")
+          }
+        end
+
+        describe 'with all options (array notify)' do
+          let(:params) do
+            {
+              ensure: 'present',
+              path: '/etc/udev/rules.d',
+              selinux_ignore_defaults: false,
+              notify_services: ["Service['systemd-udevd']", "Service['foo']"],
+              rules: [
+                '# I am a comment',
+                'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
+                'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+              ],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to create_file("/etc/udev/rules.d/#{title}")
+              .with(ensure: 'file', mode: '0444', owner: 'root', group: 'root')
+              .with_content(%r{^# I am a comment$})
+              .with_content(%r{^ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"$})
+              .with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"$})
+              .that_notifies("Service['systemd-udevd']")
+              .that_notifies("Service['foo']")
+          }
+        end
+
+        describe 'ensured absent' do
+          let(:params) { { ensure: 'absent' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to create_file("/etc/udev/rules.d/#{title}")
+              .with_ensure('absent')
+              .that_notifies("Service['systemd-udevd']")
+          end
+        end
+      end
+    end
+  end
+end

--- a/templates/udev_conf.epp
+++ b/templates/udev_conf.epp
@@ -1,0 +1,31 @@
+<%- |
+  Optional[Variant[Integer,String]]        $udev_log,
+  Optional[Integer]                        $udev_children_max,
+  Optional[Integer]                        $udev_exec_delay,
+  Optional[Integer]                        $udev_event_timeout,
+  Optional[Enum['early', 'late', 'never']] $udev_resolve_names,
+  Optional[Variant[Integer,String]]        $udev_timeout_signal
+| -%>
+# This file managed by Puppet - DO NOT EDIT
+#
+# The initial syslog(3) priority: "err", "info", "debug" or its
+# numerical equivalent. For runtime debugging, the daemons internal
+# state can be changed with: "udevadm control --log-priority=<value>".
+<% if $udev_log { -%>
+udev_log=<%= $udev_log %>
+<% } -%>
+<% if $udev_children_max { -%>
+children_max=<%= $udev_children_max %>
+<% } -%>
+<% if $udev_exec_delay { -%>
+exec_delay=<%= $udev_exec_delay %>
+<% } -%>
+<% if $udev_event_timeout { -%>
+event_timeout=<%= $udev_event_timeout %>
+<% } -%>
+<% if $udev_resolve_names { -%>
+resolve_names=<%= $udev_resolve_names %>
+<% } -%>
+<% if $udev_timeout_signal { -%>
+timeout_signal=<%= $udev_timeout_signal %>
+<% } -%>

--- a/templates/udev_rule.epp
+++ b/templates/udev_rule.epp
@@ -1,0 +1,5 @@
+<%- | Array $rules | -%>
+# This file managed by Puppet - DO NOT EDIT
+<% $rules.each | $rule | { -%>
+<%= $rule %>
+<% } -%>


### PR DESCRIPTION
With `udev` part of systemd these days, it is handy to have a place to set custom udev rules (for folks that need that like me).