### PR TITLE
introduce mail_on_failure class to setup helpers

### DIFF
--- a/files/systemd-email
+++ b/files/systemd-email
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+sendmail -t <<ERRMAIL
+To: $1
+From: systemd <root@$HOSTNAME>
+Subject: $2
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=UTF-8
+
+$(systemctl status --full "$2")
+ERRMAIL

--- a/manifests/mail_on_failure.pp
+++ b/manifests/mail_on_failure.pp
@@ -1,0 +1,41 @@
+# mail on systemd units failing
+#
+# This class manages a set of scripts that helps to
+# send out emails of failing units.
+# It prepares a unit template that can then be referenced
+# in units via OnFailure=status_email_USER@%n.service
+#
+# Email sending is handed over to sendmail and expected to
+# be allowed for user nobody.
+#
+# This is helpful to monitor failing systemd.timers in a cron-like
+# MAILTO style reporting.
+# See https://wiki.archlinux.org/index.php/Systemd/Timers#MAILTO
+# for background and implementation details.
+#
+# @param email_users
+#   Users to prepare a template unit for.
+#   By default this class prepares a template for root.
+#   Besides local users you can also define an email address.
+#   Due to the naming restrictionsof systemd units, the `@` in the template name
+#   will be replaced with `_AT_` and `ALIAS@DOMAIN` will get a unit called:
+#   `status_email_ALIAS_AT_DOMAIN@%n.service`
+#
+# @api public
+#
+class systemd::mail_on_failure (
+  Array[String[1]] $email_users = ['root'],
+) {
+  file { '/usr/local/bin/systemd-email':
+    content => file('systemd/systemd-email'),
+    owner   => 'root',
+    group   => 'systemd-journal',
+    mode    => '0750',
+  }
+  $email_users.each |$user| {
+    systemd::unit_file { "status_email_${user.regsubst(/@/,'_AT_','G')}@.service":
+      content => epp('systemd/status_email@.service.epp', { user => $user }),
+      require => File['/usr/local/bin/systemd-email'],
+    }
+  }
+}

--- a/spec/classes/mail_on_failure_spec.rb
+++ b/spec/classes/mail_on_failure_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'systemd::mail_on_failure' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} with default params" do
+        let(:facts) { facts }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('systemd::mail_on_failure') }
+        it {
+          is_expected.to contain_file('/usr/local/bin/systemd-email').with(
+            content: %r{sendmail},
+            owner: 'root',
+            group: 'systemd-journal',
+            mode: '0750',
+          )
+        }
+        # for some reason facts['networking']['fqdn'] is not valid
+        it { is_expected.to contain_systemd__unit_file('status_email_root@.service').with_content(%r{root@%H}) }
+        it { is_expected.to contain_systemd__unit_file('status_email_root@.service').that_requires('File[/usr/local/bin/systemd-email]') }
+      end
+      context "on #{os} with params" do
+        let(:facts) { facts }
+        let(:params) { { email_users: ['root', 'admin', 'monitoring@example.com'] } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('systemd::mail_on_failure') }
+        it {
+          is_expected.to contain_file('/usr/local/bin/systemd-email').with(
+            content: %r{sendmail},
+            owner: 'root',
+            group: 'systemd-journal',
+            mode: '0750',
+          )
+        }
+        it { is_expected.to contain_systemd__unit_file('status_email_root@.service').with_content(%r{root@%H}) }
+        it { is_expected.to contain_systemd__unit_file('status_email_root@.service').that_requires('File[/usr/local/bin/systemd-email]') }
+        it { is_expected.to contain_systemd__unit_file('status_email_admin@.service').with_content(%r{admin@%H}) }
+        it { is_expected.to contain_systemd__unit_file('status_email_admin@.service').that_requires('File[/usr/local/bin/systemd-email]') }
+        it { is_expected.to contain_systemd__unit_file('status_email_monitoring_AT_example.com@.service').with_content(%r{monitoring@example.com}) }
+        it { is_expected.to contain_systemd__unit_file('status_email_monitoring_AT_example.com@.service').that_requires('File[/usr/local/bin/systemd-email]') }
+      end
+    end
+  end
+end

--- a/templates/status_email@.service.epp
+++ b/templates/status_email@.service.epp
@@ -1,0 +1,16 @@
+<%| String[1] $user,
+|%>
+# THIS FILE IS MANAGED BY PUPPET
+[Unit]
+Description=Status email for %i to <%= $user %>
+
+[Service]
+Type=oneshot
+<% if $user =~ /@/ {
+  $user_email = $user
+} else {
+  $user_email = "${user}@%H"
+} -%>
+ExecStart=/usr/local/bin/systemd-email <%= $user_email %> %i
+User=nobody
+Group=systemd-journal


### PR DESCRIPTION
The helpers allow mail notifications on failing units.