### PR TITLE
Allow additional option for $cache parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 #   Takes a boolean argument or "opportunistic"
 #
 # @param cache
-#   Takes a boolean argument.
+#   Takes a boolean argument or "no-negative".
 #
 # @param dns_stub_listener
 #   Takes a boolean argument or one of "udp" and "tcp".
@@ -98,7 +98,7 @@ class systemd (
   Optional[Variant[Boolean,Enum['resolve']]]             $multicast_dns,
   Optional[Variant[Boolean,Enum['allow-downgrade']]]     $dnssec,
   Optional[Variant[Boolean,Enum['opportunistic', 'no']]] $dnsovertls,
-  Boolean                                                $cache,
+  Optional[Variant[Boolean,Enum['no-negative']]]         $cache,
   Optional[Variant[Boolean,Enum['udp','tcp']]]           $dns_stub_listener,
   Boolean                                                $use_stub_resolver,
   Boolean                                                $manage_networkd,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -99,8 +99,31 @@ describe 'systemd' do
           it { is_expected.to contain_ini_setting('llmnr') }
           it { is_expected.to contain_ini_setting('dnssec') }
           it { is_expected.to contain_ini_setting('dnsovertls') }
-          it { is_expected.to contain_ini_setting('cache') }
+          it {
+            is_expected.to contain_ini_setting('cache').with(
+              path: '/etc/systemd/resolved.conf',
+              value: 'yes',
+            )
+          }
           it { is_expected.to contain_ini_setting('dns_stub_listener') }
+        end
+
+        context 'when enabling resolved with no-negative cache variant' do
+          let(:params) do
+            {
+              manage_resolved: true,
+              cache: 'no-negative',
+            }
+          end
+
+          it { is_expected.to create_service('systemd-resolved').with_ensure('running') }
+          it { is_expected.to create_service('systemd-resolved').with_enable(true) }
+          it {
+            is_expected.to contain_ini_setting('cache').with(
+              path: '/etc/systemd/resolved.conf',
+              value: 'no-negative',
+            )
+          }
         end
 
         context 'when enabling timesyncd' do


### PR DESCRIPTION
Update the cache parameter on init class to match the allowed values for
resolved.

This addresses the issue brought up here: https://github.com/camptocamp/puppet-systemd/issues/166 

https://github.com/camptocamp/puppet-systemd/pull/140 initally added the ability to use the no-negative option for resolved, however it did not include the corresponding adjustment to allow controlling the value from the init class. 