### PR TITLE
Move lint control statements out of documentation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -203,6 +203,15 @@ Data type: `Systemd::LogindSettings`
 
 Config Hash that is used to configure settings in logind.conf
 
+##### `loginctl_users`
+
+Data type: `Hash`
+
+Config Hash that is used to generate instances of our type
+`loginctl_user`.
+
+Default value: `{}`
+
 ##### `dropin_files`
 
 Data type: `Hash`
@@ -912,7 +921,7 @@ Alias of `Struct[{
 
 The Systemd::JournaldSettings::Ensure data type.
 
-Alias of `Struct[{'ensure' => Enum['present','absent']}]`
+Alias of `Struct[{ 'ensure' => Enum['present','absent'] }]`
 
 ### `Systemd::LogindSettings`
 
@@ -949,7 +958,7 @@ Alias of `Struct[{
 
 The Systemd::LogindSettings::Ensure data type.
 
-Alias of `Struct[{'ensure' => Enum['present','absent']}]`
+Alias of `Struct[{ 'ensure' => Enum['present','absent'] }]`
 
 ### `Systemd::ServiceLimits`
 

--- a/types/journaldsettings.pp
+++ b/types/journaldsettings.pp
@@ -1,6 +1,6 @@
 # Matches Systemd journald config Struct
-# lint:ignore:140chars
 type Systemd::JournaldSettings = Struct[
+  # lint:ignore:140chars
   {
     Optional['Storage']              => Variant[Enum['volatile','persistent','auto','none'],Systemd::JournaldSettings::Ensure],
     Optional['Compress']             => Variant[Enum['yes','no'], Pattern[/^[0-9]+(K|M|G)?$/],Systemd::JournaldSettings::Ensure],
@@ -33,5 +33,5 @@ type Systemd::JournaldSettings = Struct[
     Optional['TTYPath']              => Variant[Stdlib::Absolutepath,Systemd::JournaldSettings::Ensure],
     Optional['LineMax']              => Variant[Pattern[/^[0-9]+(K|M|G|T)?$/],Systemd::JournaldSettings::Ensure],
   }
+  # lint:endignore
 ]
-# lint:endignore

--- a/types/logindsettings.pp
+++ b/types/logindsettings.pp
@@ -1,6 +1,6 @@
 # Matches Systemd Login Manager Struct
-# lint:ignore:140chars
 type Systemd::LogindSettings = Struct[
+  # lint:ignore:140chars
   {
     Optional['HandleHibernateKey']           => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitch']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
@@ -27,5 +27,5 @@ type Systemd::LogindSettings = Struct[
     Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['UserTasksMax']                 => Variant[Integer,Pattern['^(infinity|(\d+(K|M|G|T|P|E|%)?))$'],Systemd::LogindSettings::Ensure]
   }
+  # lint:endignore
 ]
-# lint:endignore


### PR DESCRIPTION
For https://github.com/camptocamp/puppet-systemd/pull/171 I was regenerating REFERENCE.md and noticed that it was out of date. It also contained ugly control statements. This fixes it.