### PR TITLE
Correct path in use_stub_resolver documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,8 +46,8 @@
 #   Takes a boolean argument or one of "udp" and "tcp".
 #
 # @param use_stub_resolver
-#   Takes a boolean argument. When "false" (default) it uses /var/run/systemd/resolve/resolv.conf
-#   as /etc/resolv.conf. When "true", it uses /var/run/systemd/resolve/stub-resolv.conf
+#   Takes a boolean argument. When "false" (default) it uses /run/systemd/resolve/resolv.conf
+#   as /etc/resolv.conf. When "true", it uses /run/systemd/resolve/stub-resolv.conf
 # @param manage_networkd
 #   Manage the systemd network daemon
 #

--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -41,8 +41,8 @@
 #   Takes a boolean argument or one of "udp" and "tcp".
 #
 # @param use_stub_resolver
-#   Takes a boolean argument. When "false" (default) it uses /var/run/systemd/resolve/resolv.conf
-#   as /etc/resolv.conf. When "true", it uses /var/run/systemd/resolve/stub-resolv.conf
+#   Takes a boolean argument. When "false" (default) it uses /run/systemd/resolve/resolv.conf
+#   as /etc/resolv.conf. When "true", it uses /run/systemd/resolve/stub-resolv.conf
 #
 class systemd::resolved (
   Enum['stopped','running'] $ensure                                  = $systemd::resolved_ensure,


### PR DESCRIPTION
d1c2ec39f2a238033a64345f31829dc6b1c0b6b9 added use_stub_resolver as a parameter but there's a mismatch between the code and documentation.  While in practice /var/run is a symlink to /run and the mismatch doesn't really matter, it's better to have them match to avoid confusion.