### PR TITLE
Make daemon-reload usable multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ systemd::unit_file { 'foo.service':
 Or handle file creation yourself and trigger systemd.
 
 ```puppet
-include systemd::systemctl::daemon_reload
+systemd::systemctl::daemon_reload { 'foo': }
 
 file { '/usr/lib/systemd/system/foo.service':
   ensure => file,
@@ -41,7 +41,7 @@ file { '/usr/lib/systemd/system/foo.service':
   mode   => '0644',
   source => "puppet:///modules/${module_name}/foo.service",
 }
-~> Class['systemd::systemctl::daemon_reload']
+~> Systemd::Systemctl::Daemon_reload['foo']
 
 service {'foo':
   ensure    => 'running',
@@ -78,7 +78,7 @@ systemd::dropin_file { 'foo.conf':
 Or handle file and directory creation yourself and trigger systemd:
 
 ```puppet
-include systemd::systemctl::daemon_reload
+systemd::systemctl::daemon_reload { 'foo': }
 
 file { '/etc/systemd/system/foo.service.d':
   ensure => directory,
@@ -93,7 +93,7 @@ file { '/etc/systemd/system/foo.service.d/foo.conf':
   mode   => '0644',
   source => "puppet:///modules/${module_name}/foo.conf",
 }
-~> Class['systemd::systemctl::daemon_reload']
+~> Systemd::Systemctl::Daemon_reload['foo']
 
 service {'foo':
   ensure    => 'running',

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -97,7 +97,8 @@ define systemd::dropin_file (
   }
 
   if $daemon_reload == 'lazy' {
-    File["${path}/${unit}.d/${filename}"] ~> Class['systemd::systemctl::daemon_reload']
+    systemd::systemctl::daemon_reload { $title: }
+    File["${path}/${unit}.d/${filename}"] ~> Systemd::Systemctl::Daemon_reload[$title]
   } else {
     File["${path}/${unit}.d/${filename}"] ~> Exec["${unit}-systemctl-daemon-reload"]
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,8 +150,6 @@ class systemd (
   Hash                                                   $dropin_files = {},
   Hash                                                   $udev_rules = {},
 ) {
-  contain systemd::systemctl::daemon_reload
-
   create_resources('systemd::service_limits', $service_limits)
 
   if $manage_resolved and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-resolved.service'] {

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -70,12 +70,13 @@ define systemd::service_limits (
   }
 
   if $restart_service {
+    systemd::systemctl::daemon_reload { $name: }
     exec { "restart ${name} because limits":
       command     => "systemctl restart ${name}",
       path        => $::path,
       refreshonly => true,
       subscribe   => File["${path}/${name}.d/90-limits.conf"],
-      require     => Class['systemd::systemctl::daemon_reload'],
+      require     => Systemd::Systemctl::Daemon_reload[$name],
     }
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -6,13 +6,14 @@ class systemd::system {
   assert_private()
 
   $systemd::accounting.each |$option, $value| {
+    systemd::systemctl::daemon_reload { $option: }
     ini_setting { $option:
       ensure  => 'present',
       path    => '/etc/systemd/system.conf',
       section => 'Manager',
       setting => $option,
       value   => $value,
-      notify  => Class['systemd::systemctl::daemon_reload'],
+      notify  => Systemd::Systemctl::Daemon_reload[$option],
     }
   }
 }

--- a/manifests/systemctl/daemon_reload.pp
+++ b/manifests/systemctl/daemon_reload.pp
@@ -1,9 +1,9 @@
 # Reload the systemctl daemon
 #
 # @api public
-class systemd::systemctl::daemon_reload {
-  exec { 'systemctl-daemon-reload':
-    command     => 'systemctl daemon-reload',
+define systemd::systemctl::daemon_reload {
+  exec { "systemctl-daemon-reload # ${title}":
+    command     => "systemctl daemon-reload # ${title}",
     refreshonly => true,
     path        => $facts['path'],
   }

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -76,6 +76,7 @@ define systemd::unit_file (
     }
   }
 
+  systemd::systemctl::daemon_reload { $name: }
   file { "${path}/${name}":
     ensure    => $_ensure,
     content   => $content,
@@ -85,7 +86,7 @@ define systemd::unit_file (
     group     => $group,
     mode      => $mode,
     show_diff => $show_diff,
-    notify    => Class['systemd::systemctl::daemon_reload'],
+    notify    => Systemd::Systemctl::Daemon_reload[$name],
   }
 
   if $enable != undef or $active != undef {
@@ -103,7 +104,7 @@ define systemd::unit_file (
       }
       Service[$name] -> File["${path}/${name}"]
     } else {
-      Class['systemd::systemctl::daemon_reload'] -> Service[$name]
+      Systemd::Systemctl::Daemon_reload[$name] -> Service[$name]
       File["${path}/${name}"] ~> Service[$name]
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,6 @@ describe 'systemd' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('systemd') }
-        it { is_expected.to create_class('systemd::systemctl::daemon_reload') }
         it { is_expected.to contain_class('systemd::journald') }
         it { is_expected.to create_service('systemd-journald') }
         it { is_expected.to have_ini_setting_resource_count(0) }

--- a/spec/defines/dropin_file_spec.rb
+++ b/spec/defines/dropin_file_spec.rb
@@ -45,7 +45,7 @@ describe 'systemd::dropin_file' do
         end
 
         context 'with daemon_reload => lazy (default)' do
-          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies('Class[systemd::systemctl::daemon_reload]') }
+          it { is_expected.to create_file("/etc/systemd/system/#{params[:unit]}.d/#{title}").that_notifies("Systemd::Systemctl::Daemon_reload[#{title}]") }
 
           it { is_expected.not_to create_exec("#{params[:unit]}-systemctl-daemon-reload") }
         end

--- a/spec/defines/systemctl/daemon_reload_spec.rb
+++ b/spec/defines/systemctl/daemon_reload_spec.rb
@@ -6,9 +6,10 @@ describe 'systemd::systemctl::daemon_reload' do
       context "on #{os}" do
         let(:facts) { facts }
 
+        let(:title) { 'test1' }
+
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('systemd::systemctl::daemon_reload') }
-        it { is_expected.to create_exec('systemctl-daemon-reload') }
+        it { is_expected.to create_exec("systemctl-daemon-reload # #{title}") }
       end
     end
   end


### PR DESCRIPTION
This PR changes the behavior of systemd::systemctl::daemon_reload by
migrating from a class to a defined type.

This allows usage of multiple e.g. systemd::unit_file types in different classes
with strict ordering.

Downside: systemctl daemon-reload might be called multiple times during initial
setup.

Fixes #178

Needs major version bump due to migration from class to defined type