### PR TITLE
Fix clash with modules that manage the unit folder too

### DIFF
--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -65,7 +65,7 @@ define systemd::dropin_file (
     }
   }
 
-  if $ensure != 'absent' {
+  if $ensure != 'absent' and !defined(File["${path}/${unit}.d"]) {
     ensure_resource('file', "${path}/${unit}.d", {
         ensure                  => directory,
         owner                   => 'root',


### PR DESCRIPTION
Other puppet modules in a puppet setup might manage the `{unit}.d` folder as well. For example puppetlabs/docker does (See https://github.com/puppetlabs/puppetlabs-docker/blob/main/manifests/service.pp).
If one still wants to add limits overrides via this systemd module, puppet will complain about duplicate resource declaration.