### PR TITLE
metadata: allow stdlib 7.0.0 and inifile 5.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 5.0.0"
+      "version_requirement": ">= 1.6.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Allow use with the latest versions of these puppetlabs modules.