### PR TITLE
Bump version to 3.0.0-rc0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "camptocamp-systemd",
-  "version": "2.12.0",
+  "version": "3.0.0-rc0",
   "author": "camptocamp",
   "summary": "Puppet Systemd module",
   "license": "Apache-2.0",


### PR DESCRIPTION
97dd16fa32886b5b0f77a6f38a4953d4c1511c0e was a breaking change. Bumping the version helps consuming modules to make a distinction with the following code:

```puppet
$metadata = load_module_metadata('systemd')
if SemVer($metadata['version']) >= SemVer('3.0.0') {}
```

My use cases is:

```puppet
systemd::unit_file { 'myservice.socket':
  content => file('mymodule/myservice.socket'),
  enable  => true,
  active  => true,
}
systemd::unit_file { 'myservice.service':
  content => file('mymodule/myservice.service'),
  enable  => true,
  active  => true,
}
$metadata = load_module_metadata('systemd')
if SemVer($metadata['version']) >= SemVer('3.0.0') {
  Systemd::Unit_file['myservice.socket'] -> Systemd::Unit_file['myservice.service']
}
```

This allows me to maintain Puppet 5 support for a bit longer while also working with the latest version.