### PR TITLE
Add notify_service support to dropin_file

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -374,6 +374,7 @@ The following parameters are available in the `systemd::dropin_file` defined typ
 * [`group`](#group)
 * [`mode`](#mode)
 * [`show_diff`](#show_diff)
+* [`notify_service`](#notify_service)
 * [`unit`](#unit)
 * [`filename`](#filename)
 * [`ensure`](#ensure)
@@ -461,6 +462,14 @@ Data type: `Boolean`
 Whether to show the diff when updating dropin file
 
 Default value: ``true``
+
+##### <a name="notify_service"></a>`notify_service`
+
+Data type: `Boolean`
+
+Notify a service for the unit, if it exists
+
+Default value: ``false``
 
 ##### <a name="unit"></a>`unit`
 


### PR DESCRIPTION
It is very common that a drop in file should notify a service that's managed elsewhere. This adds a parameter to do so which then uses a collector.

Review notes:
* Should the parent directory also notify the service? My main reasoning be that if it purges unknown files, it should also notify the service. I don't even know if that works
* I made it default to false to be compatible. This makes it a bit hard to use though.
* Should this be exposed on any defined type that uses dropin_file?