### PR TITLE
Allow to disable the DNS stub listener

### DIFF
--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -239,7 +239,7 @@ class systemd::resolved (
     default => $dns_stub_listener,
   }
 
-  if  $dns_stub_listener =~ String[1] {
+  if $dns_stub_listener =~ NotUndef {
     ini_setting { 'dns_stub_listener':
       ensure  => stdlib::ensure($dns_stub_listener != 'absent'),
       value   => $_dns_stub_listener,


### PR DESCRIPTION
I guess #429 broke the ability to set

```
    class { '::systemd':
        dns_stub_listener => false,
    }
```

... and get `DNSStubListener = no` in `/etc/systemd/resolved.conf`, which was working before.

I am not at all familiar with the test suite here or Ruby tests in general, so I could use some help to make this pass.
