### PR TITLE
Add `AssertFileNotEmpty` as optional parameter for unit

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6088,6 +6088,7 @@ Struct[{
     # Conditions and Asserts
     Optional['AssertPathExists']            => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['AssertPathIsDirectory']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertFileNotEmpty']          => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathExists']         => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathExistsGlob']     => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory']    => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],

--- a/spec/type_aliases/systemd_unit_unit_spec.rb
+++ b/spec/type_aliases/systemd_unit_unit_spec.rb
@@ -78,7 +78,7 @@ describe 'Systemd::Unit::Unit' do
     end
   end
 
-  %w[ConditionPathExists ConditionPathIsDirectory AssertPathExists AssertPathIsDirectory].each do |assert|
+  %w[ConditionPathExists ConditionPathIsDirectory AssertPathExists AssertPathIsDirectory AssertFileNotEmpty].each do |assert|
     context "with a key of #{assert} can have files or negated files" do
       it { is_expected.to allow_value({ assert.to_s => '/my/existing/file' }) }
       it { is_expected.to allow_value({ assert.to_s => '!/my/existing/file' }) }

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -39,6 +39,7 @@ type Systemd::Unit::Unit = Struct[
     # Conditions and Asserts
     Optional['AssertPathExists']            => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['AssertPathIsDirectory']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertFileNotEmpty']          => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathExists']         => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathExistsGlob']     => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory']    => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],


### PR DESCRIPTION
#### Pull Request (PR) description
Add `AssertFileNotEmpty` as an optional parameter for a unit entry, similar to ConditionFileNotEmpty, just logged more loudly :)

https://man7.org/linux/man-pages/man5/systemd.unit.5.html
           Added in version 218
