### PR TITLE
Use `runuser`/`run0` to connect to `systemd --user` instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,25 @@ class { 'systemd':
 }
 ```
 
+### User Services
+
+User services can be managed
+
+```puppet
+
+systemd::user_service { 'hour.service':
+  ensure => true,
+  enable => true,
+  user   => 'higgs',
+}
+```
+
+This will run `systemctl --user enable hour.service` and `systemctl --user start hour.service` as the user higgs.
+
+On Debian 12 and RHEL9 the `runuser` command is used for `systemd::user_service` which can be installed with
+the `runuser => true` parameter to the main class. Newer operating systems use `run0` which is always available with `systemd`.
+
+
 ### journald configuration
 
 It also allows you to manage journald settings. You can manage journald settings through setting the `journald_settings` parameter. If you want a parameter to be removed, you can pass its value as params.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -53,6 +53,7 @@
 ### Functions
 
 * [`systemd::escape`](#systemd--escape): Escape strings as systemd-escape does.
+* [`systemd::systemctl_user`](#systemd--systemctl_user): Construct command array for running `systemctl --user` for particular arguments
 * [`systemd::systemd_escape`](#systemd--systemd_escape): Escape strings by call the `systemd-escape` command in the background.
 
 ### Data types
@@ -269,6 +270,7 @@ The following parameters are available in the `systemd` class:
 * [`system_settings`](#-systemd--system_settings)
 * [`manage_user_conf`](#-systemd--manage_user_conf)
 * [`user_settings`](#-systemd--user_settings)
+* [`install_runuser`](#-systemd--install_runuser)
 
 ##### <a name="-systemd--default_target"></a>`default_target`
 
@@ -895,6 +897,14 @@ NOTE: It's currently impossible to have multiple entries of the same key in
 the settings.
 
 Default value: `{}`
+
+##### <a name="-systemd--install_runuser"></a>`install_runuser`
+
+Data type: `Boolean`
+
+If true, the util-linux package is installed, for runuser command.
+
+Default value: `false`
 
 ### <a name="systemd--tmpfiles"></a>`systemd::tmpfiles`
 
@@ -2793,6 +2803,9 @@ Manage a user service running under systemd --user
 ##### Enable a service for all users
 
 ```puppet
+class { 'systemd':
+  install_runuser => true,
+}
 systemd::user_service { 'systemd-tmpfiles-clean.timer':
   enable => true,
   global => true,
@@ -2971,6 +2984,50 @@ Input string
 Data type: `Boolean`
 
 Use path (-p) ornon-path  style escaping.
+
+### <a name="systemd--systemctl_user"></a>`systemd::systemctl_user`
+
+Type: Puppet Language
+
+Construct command array for running `systemctl --user` for particular arguments
+
+#### Examples
+
+##### Start a user service with an exec
+
+```puppet
+exec { 'start_service':
+ command => systemd::systemctl_user('santa', 'start myservice.service'),
+}
+```
+
+#### `systemd::systemctl_user(String[1] $user, Array[String[1],1] $arguments)`
+
+The systemd::systemctl_user function.
+
+Returns: `Array` Array Array of command and arguments
+
+##### Examples
+
+###### Start a user service with an exec
+
+```puppet
+exec { 'start_service':
+ command => systemd::systemctl_user('santa', 'start myservice.service'),
+}
+```
+
+##### `user`
+
+Data type: `String[1]`
+
+User instance of `systemd --user` to connect to.
+
+##### `arguments`
+
+Data type: `Array[String[1],1]`
+
+Arguments to run after `systemctl --user`
 
 ### <a name="systemd--systemd_escape"></a>`systemd::systemd_escape`
 

--- a/functions/systemctl_user.pp
+++ b/functions/systemctl_user.pp
@@ -1,0 +1,29 @@
+# @summary Construct command array for running `systemctl --user` for particular arguments
+# @param user User instance of `systemd --user` to connect to.
+# @param arguments Arguments to run after `systemctl --user`
+#
+# @return Array Array of command and arguments
+# @example Start a user service with an exec
+#   exec { 'start_service':
+#    command => systemd::systemctl_user('santa', 'start myservice.service'),
+#   }
+function systemd::systemctl_user(String[1] $user, Array[String[1],1] $arguments) >> Array {
+  # Why is runuser being used here for older systemds?
+  # More obvious command arrays to return would be:
+  # * ['run0','--user',$user,'systemctl','--user'] + $arguments
+  # * ['systemctl', '--user', '--machine', "${user}@.host"] + $arguments
+  # * ['systemd-run','--wait','--pipe', 'systemctl', '--user', '--machine', "${user}@.host"] + $arguments
+  # However none of these work when puppet is run as a background service. They only work with
+  # puppet apply in the foreground. Reason is unclear, possibly polkit blocking access
+  # https://github.com/voxpupuli/puppet-systemd/issues/459
+
+  $_cmd_array  = Integer($facts['systemd_version']) < 256 ? {
+    true    => [
+      'runuser', '-u', $user, '--' ,'/usr/bin/bash', '-c',
+      "env XDG_RUNTIME_DIR=/run/user/\$(id -u) /usr/bin/systemctl --user ${arguments.join(' ')}",
+    ],
+    default => ['run0','--user',$user,'/usr/bin/systemctl','--user'] + $arguments,
+  }
+
+  return $_cmd_array
+}

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -42,7 +42,7 @@ define systemd::daemon_reload (
       }
 
       $_title   = "${module_name}-${name}-systemctl-user-${user}-daemon-reload"
-      $_command = ['systemd-run', '--pipe', '--wait', '--user', '--machine', "${user}@.host", 'systemctl', '--user', 'daemon-reload']
+      $_command = systemd::systemctl_user($user, ['daemon-reload'])
     } else {
       $_title   = "${module_name}-${name}-systemctl-daemon-reload"
       $_command = ['systemctl', 'daemon-reload']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,6 +256,10 @@
 #   Config Hash that is used to configure settings in user.conf
 #   NOTE: It's currently impossible to have multiple entries of the same key in
 #   the settings.
+#
+# @param install_runuser
+#   If true, the util-linux package is installed, for runuser command.
+#
 class systemd (
   Optional[Pattern['^.+\.target$']]                   $default_target = undef,
   Hash[String,String]                                 $accounting = {},
@@ -331,6 +335,7 @@ class systemd (
   Systemd::ServiceManagerSettings                     $system_settings = {},
   Boolean                                             $manage_user_conf = false,
   Systemd::ServiceManagerSettings                     $user_settings = {},
+  Boolean                                             $install_runuser = false,
 ) {
   contain systemd::install
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,4 +39,10 @@ class systemd::install {
       ensure => present,
     }
   }
+
+  if $systemd::install_runuser {
+    package { 'util-linux':
+      ensure => installed,
+    }
+  }
 }

--- a/spec/acceptance/user_service_spec.rb
+++ b/spec/acceptance/user_service_spec.rb
@@ -9,7 +9,8 @@ describe 'systemd::user_service' do
 
         # systemd-logind.service must be running.
         class{ 'systemd':
-          manage_logind => true,
+          manage_logind   => true,
+          install_runuser => true,
         }
 
         user { 'higgs' :
@@ -19,6 +20,13 @@ describe 'systemd::user_service' do
 
         loginctl_user{'higgs':
           linger  => enabled,
+        }
+
+        # https://github.com/voxpupuli/puppet-systemd/issues/578
+        exec{'/usr/bin/sleep 10 && touch /tmp/sleep-only-once':
+          creates   => '/tmp/sleep-only-once',
+          require   => Loginctl_user['higgs'],
+          before    => File['/home/higgs/.config'],
         }
 
         # Assumes home directory was created as /home/higgs

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,6 +21,7 @@ describe 'systemd' do
         it { is_expected.not_to contain_package('systemd-timesyncd') }
         it { is_expected.not_to contain_package('systemd-resolved') }
         it { is_expected.not_to contain_package('systemd-container') }
+        it { is_expected.not_to contain_package('util-linux') }
         it { is_expected.not_to contain_class('systemd::coredump') }
         it { is_expected.not_to contain_class('systemd::oomd') }
         it { is_expected.not_to contain_exec('systemctl set-default multi-user.target') }
@@ -1187,6 +1188,14 @@ describe 'systemd' do
             it { is_expected.to contain_systemd__dropin_file('coredump_backtrace.conf').with_ensure('file') }
             it { is_expected.to contain_systemd__dropin_file('coredump_backtrace.conf').with_content(%r{^ExecStart=.*--backtrace$}) }
           end
+        end
+
+        context 'with install_runuser true' do
+          let :params do
+            { install_runuser: true }
+          end
+
+          it { is_expected.to contain_package('util-linux').with_ensure('installed') }
         end
       end
     end

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -6,7 +6,7 @@ describe 'systemd::daemon_reload' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) { facts }
+        let(:facts) { facts.merge(systemd_version: '256') }
         let(:title) { 'irregardless' }
 
         it { is_expected.to compile.with_all_deps }
@@ -36,7 +36,7 @@ describe 'systemd::daemon_reload' do
 
               it {
                 is_expected.to contain_exec('systemd-irregardless-systemctl-user-steve-daemon-reload').
-                  with_command(['systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host', 'systemctl', '--user', 'daemon-reload']).
+                  with_command(['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'daemon-reload']).
                   with_refreshonly(true)
               }
 

--- a/spec/defines/user_service_spec.rb
+++ b/spec/defines/user_service_spec.rb
@@ -6,7 +6,7 @@ describe 'systemd::user_service' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) { facts }
+        let(:facts) { facts.merge(systemd_version: '256') }
         let(:title) { 'mine.timer' }
 
         context 'with defaults' do
@@ -73,27 +73,23 @@ describe 'systemd::user_service' do
 
             it {
               is_expected.to contain_exec('Stop user service mine.timer for user steve').
-                with_command([
-                               'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                               'systemctl', '--user', 'stop', 'mine.timer',
-                             ]).
-                with_onlyif([[
-                              'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                              'systemctl', '--user', 'is-active', 'mine.timer',
-                            ]]).
+                with_command(
+                  ['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'stop', 'mine.timer']
+                ).
+                with_onlyif(
+                  [['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'is-active', 'mine.timer']]
+                ).
                 without_unless
             }
 
             it {
               is_expected.to contain_exec('Disable user service mine.timer for user steve').
-                with_command([
-                               'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                               'systemctl', '--user', 'disable', 'mine.timer',
-                             ]).
-                with_onlyif([[
-                              'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                              'systemctl', '--user', 'is-enabled', 'mine.timer',
-                            ]]).
+                with_command(
+                  ['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'disable', 'mine.timer']
+                ).
+                with_onlyif(
+                  [['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'is-enabled', 'mine.timer']]
+                ).
                 without_unless
             }
           end
@@ -105,28 +101,24 @@ describe 'systemd::user_service' do
 
             it {
               is_expected.to contain_exec('Start user service mine.timer for user steve').
-                with_command([
-                               'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                               'systemctl', '--user', 'start', 'mine.timer',
-                             ]).
+                with_command(
+                  ['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'start', 'mine.timer']
+                ).
                 without_onlyif.
-                with_unless([[
-                              'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                              'systemctl', '--user', 'is-active', 'mine.timer',
-                            ]])
+                with_unless(
+                  [['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'is-active', 'mine.timer']]
+                )
             }
 
             it {
               is_expected.to contain_exec('Enable user service mine.timer for user steve').
-                with_command([
-                               'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                               'systemctl', '--user', 'enable', 'mine.timer',
-                             ]).
+                with_command(
+                  ['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'enable', 'mine.timer']
+                ).
                 without_onlif.
-                with_unless([[
-                              'systemd-run', '--pipe', '--wait', '--user', '--machine', 'steve@.host',
-                              'systemctl', '--user', 'is-enabled', 'mine.timer',
-                            ]])
+                with_unless(
+                  [['run0', '--user', 'steve', '/usr/bin/systemctl', '--user', 'is-enabled', 'mine.timer']]
+                )
             }
           end
 

--- a/spec/functions/systemctl_user_spec.rb
+++ b/spec/functions/systemctl_user_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+describe 'systemd::systemctl_user' do
+  context 'with old systemd' do
+    let(:facts) do
+      { systemd_version: '222' }
+    end
+
+    context 'with valid input' do
+      it {
+        is_expected.to run.with_params('foo', ['status', 'my.service']).and_return(
+          [
+            'runuser', '-u', 'foo', '--', '/usr/bin/bash', '-c',
+            'env XDG_RUNTIME_DIR=/run/user/$(id -u) /usr/bin/systemctl --user status my.service'
+          ]
+        )
+      }
+
+      it {
+        is_expected.to run.with_params('foo', ['is-enabled', 'my.service']).and_return(
+          [
+            'runuser', '-u', 'foo', '--', '/usr/bin/bash', '-c',
+            'env XDG_RUNTIME_DIR=/run/user/$(id -u) /usr/bin/systemctl --user is-enabled my.service'
+          ]
+        )
+      }
+    end
+  end
+
+  context 'with new systemd' do
+    let(:facts) do
+      { systemd_version: '256' }
+    end
+
+    context 'with valid input' do
+      it {
+        is_expected.to run.with_params('foo', ['status', 'my.service']).and_return(
+          ['run0', '--user', 'foo', '/usr/bin/systemctl', '--user', 'status', 'my.service']
+        )
+      }
+
+      it {
+        is_expected.to run.with_params('foo', ['is-enabled', 'my.service']).and_return(
+          ['run0', '--user', 'foo', '/usr/bin/systemctl', '--user', 'is-enabled', 'my.service']
+        )
+      }
+    end
+  end
+
+  context 'with invalid input' do
+    it { is_expected.not_to run.with_params('foo') }
+    it { is_expected.not_to run.with_params('foo', 'bar') }
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Create a new function `systemd::systemctl_user` to construct array of command and args used to contact `systemd --user` instances so `systemctl --user status my.service` can be executed.

On systemd >= 256 `run0` is used with `runuser` used on older OSes (RHEL9, Debian 12, .. )

A new boolean is also added `install_runuser` to install `util-linux` if needed which seems to be the correct package for all distributions. In reality this package will be installed on most systems anyway.

We switch to using `runuser` or `run0` to become the user since:

* Using `systemctl` or `systemd-run` with `--machinectl $user@.host` always fails when puppet is ran inside its own systemd unit. I believe systemd services can not access `systemd --user` instances.
* We use `runuser -u $user` rather than a `user => $user` on the exec since the $(id -u $user) must be resolved late within the exec itself.

Now the command is generated inside a function this will make future improvements to this method much simpler.

#### This Pull Request (PR) fixes the following issues

* Fixes #459 