### PR TITLE
fix: networkd is not an internal service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -384,7 +384,7 @@ class systemd (
     Class['systemd::install'] -> Class['systemd::resolved']
   }
 
-  if $manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
+  if $manage_networkd {
     contain systemd::networkd
     Class['systemd::install'] -> Class['systemd::networkd']
   }

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -26,7 +26,7 @@ define systemd::network (
 ) {
   include systemd
 
-  if $restart_service and $systemd::manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
+  if $restart_service and $systemd::manage_networkd {
     $notify = Service['systemd-networkd']
   } else {
     $notify = undef


### PR DESCRIPTION
systemd-networkd is an external package managed by the module and existing code doesn't manage service until second puppet run
