### PR TITLE
networkd: stop all socket units to prevent socket activation restart

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -49,6 +49,28 @@ Facter.add(:systemd_version) do
   end
 end
 
+# Fact: systemd_networkd_socket_units
+#
+# Purpose:
+#   List all systemd-networkd socket units present on the system
+#
+# Resolution:
+#   Check unit files matching systemd-networkd*.socket. The set of socket units
+#   has grown over time (systemd 260+ ships additional varlink socket units);
+#   this fact returns whatever is present so the manifest can manage them all.
+#
+# Caveats:
+#
+Facter.add(:systemd_networkd_socket_units) do
+  confine systemd: true
+  setcode do
+    command_output = Facter::Util::Resolution.exec(
+      'systemctl list-unit-files --no-legend --no-pager "systemd-networkd*.socket" 2>/dev/null',
+    )
+    command_output.lines.map { |line| line.split.first }.compact
+  end
+end
+
 Facter.add(:systemd_internal_services) do
   confine systemd: true
   setcode do

--- a/manifests/networkd.pp
+++ b/manifests/networkd.pp
@@ -2,7 +2,10 @@
 #
 # @summary This class provides an abstract way to trigger systemd-networkd
 #
-# @param ensure The state that the ``networkd`` service should be in
+# @param ensure The state that the ``networkd`` service should be in.
+#   When set to ``stopped``, any ``systemd-networkd*.socket`` units present on
+#   the node are also stopped before the service to prevent socket activation
+#   from immediately restarting it.
 # @param path path where all networkd files are placed in
 # @param manage_all_network_files if enabled, all networkd files that aren't managed by puppet will be purged
 # @param link_profiles
@@ -60,6 +63,23 @@ class systemd::networkd (
     'stopped' => false,
     'running' => true,
     default   => $ensure,
+  }
+
+  # Newer systemd versions (260+) ship additional socket units for networkd
+  # (systemd-networkd-varlink.socket, systemd-networkd-varlink-metrics.socket,
+  # systemd-networkd-resolve-hook.socket). When any remain active, systemd
+  # re-activates systemd-networkd.service immediately via socket activation.
+  # Stop all present socket units before the service to prevent this.
+  # Only act when stopping — starting networkd does not require managing sockets
+  # explicitly, and doing so would override a user's deliberate socket configuration.
+  # Guard against undef in case the fact is not collected (e.g. non-systemd node).
+  if $ensure == 'stopped' and $facts['systemd_networkd_socket_units'] =~ Array {
+    $facts['systemd_networkd_socket_units'].each |$socket| {
+      service { $socket:
+        ensure => stopped,
+        before => Service['systemd-networkd'],
+      }
+    }
   }
 
   service { 'systemd-networkd':

--- a/spec/classes/networkd_spec.rb
+++ b/spec/classes/networkd_spec.rb
@@ -53,6 +53,34 @@ describe 'systemd::networkd' do
       it {
         is_expected.to contain_file('/etc/systemd/network/50-vrf.link')
       }
+
+      context 'with networkd_ensure => stopped' do
+        let(:facts) { os_facts.merge({ systemd_networkd_socket_units: ['systemd-networkd.socket'] }) }
+        let(:pre_condition) do
+          [
+            'class { "systemd": manage_networkd => true, networkd_ensure => "stopped" }',
+            'function assert_private () { }',
+          ]
+        end
+
+        it {
+          is_expected.to contain_service('systemd-networkd.socket')
+            .with_ensure('stopped')
+            .that_comes_before('Service[systemd-networkd]')
+        }
+      end
+
+      context 'with networkd_ensure => running' do
+        let(:facts) { os_facts.merge({ systemd_networkd_socket_units: ['systemd-networkd.socket'] }) }
+        let(:pre_condition) do
+          [
+            'class { "systemd": manage_networkd => true, networkd_ensure => "running" }',
+            'function assert_private () { }',
+          ]
+        end
+
+        it { is_expected.not_to contain_service('systemd-networkd.socket') }
+      end
     end
   end
 end

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,4 +1,6 @@
 ---
+systemd_networkd_socket_units:
+  - systemd-networkd.socket
 systemd_internal_services:
   systemd-fsck-root.service: enabled-runtime
   systemd-journal-gatewayd.service: indirect


### PR DESCRIPTION
#### Pull Request (PR) description

On systemd 260+ (Archlinux rolling), additional socket units
(`systemd-networkd-varlink.socket`, `systemd-networkd-varlink-metrics.socket`,
`systemd-networkd-resolve-hook.socket`) cause systemd to immediately re-activate
`systemd-networkd.service` via socket activation when it is stopped, making
`networkd_ensure => stopped` non-idempotent.

Add a `systemd_networkd_socket_units` fact that discovers all
`systemd-networkd*.socket` unit files present on the node. The manifest
iterates over them, stopping all socket units before stopping the service.
This handles the current set of sockets as well as any added in future
systemd versions.

On platforms where systemd-networkd is not installed (RHEL/CentOS) the fact
returns an empty array and no socket resources are declared.

#### This Pull Request (PR) fixes the following issues

Fixes #612