### PR TITLE
Fixup "Per{xyz}" as these unicode characters are valid sometimes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -176,6 +176,8 @@
 * [`Systemd::Unit::Mount`](#Systemd--Unit--Mount): Possible keys for the [Mount] section of a unit file
 * [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
 * [`Systemd::Unit::Percent`](#Systemd--Unit--Percent): Systemd definition of a percentage
+* [`Systemd::Unit::Permille`](#Systemd--Unit--Permille): Systemd definition of a permille value (‰, 1/1000)
+* [`Systemd::Unit::Permyriad`](#Systemd--Unit--Permyriad): Systemd definition of a permyriad value (‱, 1/10000)
 * [`Systemd::Unit::Service`](#Systemd--Unit--Service): Possible keys for the [Service] section of a unit file
 * [`Systemd::Unit::Service::Exec`](#Systemd--Unit--Service--Exec): Possible strings for ExecStart, ExecStartPrep, ...
 * [`Systemd::Unit::Slice`](#Systemd--Unit--Slice): Possible keys for the [Slice] section of a unit file
@@ -5775,8 +5777,8 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['SwapUsedLimit']                    => Pattern[/^[0-9]+[%|‰|‱]$/],
-    Optional['DefaultMemoryPressureLimit']       => Pattern[/^[0-9]+%$/],
+    Optional['SwapUsedLimit']                    => Variant[Systemd::Unit::Percent,Systemd::Unit::Permille,Systemd::Unit::Permyriad],
+    Optional['DefaultMemoryPressureLimit']       => Variant[Systemd::Unit::Percent,Systemd::Unit::Permille,Systemd::Unit::Permyriad],
     Optional['DefaultMemoryPressureDurationSec'] => Integer[0],
   }]
 ```
@@ -6053,6 +6055,24 @@ Systemd definition of a percentage
   * https://www.freedesktop.org/software/systemd/man/systemd.slice.html
 
 Alias of `Pattern['\A([0-9][0-9]?|100)%\z']`
+
+### <a name="Systemd--Unit--Permille"></a>`Systemd::Unit::Permille`
+
+Systemd definition of a permille value (‰, 1/1000)
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+
+Alias of `Pattern['\A(0|[1-9][0-9]?[0-9]?|1000)‰\z']`
+
+### <a name="Systemd--Unit--Permyriad"></a>`Systemd::Unit::Permyriad`
+
+Systemd definition of a permyriad value (‱, 1/10000)
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/oomd.conf.html
+
+Alias of `Pattern['\A(0|[1-9][0-9]?[0-9]?[0-9]?|10000)‱\z']`
 
 ### <a name="Systemd--Unit--Service"></a>`Systemd::Unit::Service`
 

--- a/spec/type_aliases/systemd_oomdsettings_spec.rb
+++ b/spec/type_aliases/systemd_oomdsettings_spec.rb
@@ -33,8 +33,19 @@ describe 'Systemd::OomdSettings' do
     )
   }
 
+  it {
+    is_expected.to allow_value(
+      {
+        'SwapUsedLimit' => '500‰',
+        'DefaultMemoryPressureLimit' => '5000‱',
+      },
+    )
+  }
+
   it { is_expected.not_to allow_value({ 'SwapUsedLimit' => '60' }) }
   it { is_expected.not_to allow_value({ 'SwapUsedLimit' => '%' }) }
+  it { is_expected.not_to allow_value({ 'SwapUsedLimit' => '60|' }) }
   it { is_expected.not_to allow_value({ 'DefaultMemoryPressureLimit' => '10' }) }
+  it { is_expected.not_to allow_value({ 'DefaultMemoryPressureLimit' => '10|' }) }
   it { is_expected.not_to allow_value({ 'DefaultMemoryPressureDurationSec' => -10 }) }
 end

--- a/spec/type_aliases/systemd_unit_percent_spec.rb
+++ b/spec/type_aliases/systemd_unit_percent_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 describe 'Systemd::Unit::Percent' do
+  it { is_expected.to allow_value('0%') }
   it { is_expected.to allow_value('1%') }
   it { is_expected.to allow_value('100%') }
 

--- a/spec/type_aliases/systemd_unit_permille_spec.rb
+++ b/spec/type_aliases/systemd_unit_permille_spec.rb
@@ -3,12 +3,12 @@
 require 'spec_helper'
 
 describe 'Systemd::Unit::Permille' do
+  it { is_expected.to allow_value('0‰') }
   it { is_expected.to allow_value('1‰') }
   it { is_expected.to allow_value('500‰') }
   it { is_expected.to allow_value('1000‰') }
 
   it { is_expected.not_to allow_value(1) }
-  it { is_expected.not_to allow_value('0‰') }
   it { is_expected.not_to allow_value('1001‰') }
   it { is_expected.not_to allow_value('50%') }
   it { is_expected.not_to allow_value('50‱') }

--- a/spec/type_aliases/systemd_unit_permille_spec.rb
+++ b/spec/type_aliases/systemd_unit_permille_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Permille' do
+  it { is_expected.to allow_value('1‰') }
+  it { is_expected.to allow_value('500‰') }
+  it { is_expected.to allow_value('1000‰') }
+
+  it { is_expected.not_to allow_value(1) }
+  it { is_expected.not_to allow_value('0‰') }
+  it { is_expected.not_to allow_value('1001‰') }
+  it { is_expected.not_to allow_value('50%') }
+  it { is_expected.not_to allow_value('50‱') }
+end

--- a/spec/type_aliases/systemd_unit_permyriad_spec.rb
+++ b/spec/type_aliases/systemd_unit_permyriad_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Permyriad' do
+  it { is_expected.to allow_value('1‱') }
+  it { is_expected.to allow_value('5000‱') }
+  it { is_expected.to allow_value('10000‱') }
+
+  it { is_expected.not_to allow_value(1) }
+  it { is_expected.not_to allow_value('0‱') }
+  it { is_expected.not_to allow_value('10001‱') }
+  it { is_expected.not_to allow_value('50%') }
+  it { is_expected.not_to allow_value('50‰') }
+end

--- a/spec/type_aliases/systemd_unit_permyriad_spec.rb
+++ b/spec/type_aliases/systemd_unit_permyriad_spec.rb
@@ -3,12 +3,12 @@
 require 'spec_helper'
 
 describe 'Systemd::Unit::Permyriad' do
+  it { is_expected.to allow_value('0‱') }
   it { is_expected.to allow_value('1‱') }
   it { is_expected.to allow_value('5000‱') }
   it { is_expected.to allow_value('10000‱') }
 
   it { is_expected.not_to allow_value(1) }
-  it { is_expected.not_to allow_value('0‱') }
   it { is_expected.not_to allow_value('10001‱') }
   it { is_expected.not_to allow_value('50%') }
   it { is_expected.not_to allow_value('50‰') }

--- a/types/oomdsettings.pp
+++ b/types/oomdsettings.pp
@@ -3,8 +3,8 @@
 #
 type Systemd::OomdSettings = Struct[
   {
-    Optional['SwapUsedLimit']                    => Pattern[/^[0-9]+[%|‰|‱]$/],
-    Optional['DefaultMemoryPressureLimit']       => Pattern[/^[0-9]+%$/],
+    Optional['SwapUsedLimit']                    => Variant[Systemd::Unit::Percent,Systemd::Unit::Permille,Systemd::Unit::Permyriad],
+    Optional['DefaultMemoryPressureLimit']       => Variant[Systemd::Unit::Percent,Systemd::Unit::Permille,Systemd::Unit::Permyriad],
     Optional['DefaultMemoryPressureDurationSec'] => Integer[0],
   }
 ]

--- a/types/unit/permille.pp
+++ b/types/unit/permille.pp
@@ -1,0 +1,4 @@
+# @summary Systemd definition of a permille value (‰, 1/1000)
+# @see https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+#
+type Systemd::Unit::Permille = Pattern['\A([1-9][0-9]?[0-9]?|1000)‰\z']

--- a/types/unit/permille.pp
+++ b/types/unit/permille.pp
@@ -1,4 +1,4 @@
 # @summary Systemd definition of a permille value (‰, 1/1000)
 # @see https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 #
-type Systemd::Unit::Permille = Pattern['\A([1-9][0-9]?[0-9]?|1000)‰\z']
+type Systemd::Unit::Permille = Pattern['\A(0|[1-9][0-9]?[0-9]?|1000)‰\z']

--- a/types/unit/permyriad.pp
+++ b/types/unit/permyriad.pp
@@ -1,4 +1,4 @@
 # @summary Systemd definition of a permyriad value (‱, 1/10000)
 # @see https://www.freedesktop.org/software/systemd/man/oomd.conf.html
 #
-type Systemd::Unit::Permyriad = Pattern['\A([1-9][0-9]?[0-9]?[0-9]?|10000)‱\z']
+type Systemd::Unit::Permyriad = Pattern['\A(0|[1-9][0-9]?[0-9]?[0-9]?|10000)‱\z']

--- a/types/unit/permyriad.pp
+++ b/types/unit/permyriad.pp
@@ -1,0 +1,4 @@
+# @summary Systemd definition of a permyriad value (‱, 1/10000)
+# @see https://www.freedesktop.org/software/systemd/man/oomd.conf.html
+#
+type Systemd::Unit::Permyriad = Pattern['\A([1-9][0-9]?[0-9]?[0-9]?|10000)‱\z']


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds in the missing per types and updates oomd to use them.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
