### PR TITLE
Stop network sockets for tests on v250

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -523,7 +523,7 @@ Default value: `false`
 
 Data type: `Enum['stopped','running']`
 
-The state that the ``networkd`` service should be in
+The state that the ``networkd`` service should be in. **Warning** Since since v260 of systemd ensuring the service is stopped may only be transient, it is very likely some socket will activate the service nearly immediatly.
 
 Default value: `'running'`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@
 #   Manage the systemd network daemon
 #
 # @param networkd_ensure
-#   The state that the ``networkd`` service should be in
+#   The state that the ``networkd`` service should be in. **Warning** Since since v260 of systemd ensuring the service is stopped may only be transient, it is very likely some socket will activate the service nearly immediatly. 
 #
 # @param networkd_package
 #   Name of the package required for systemd-networkd, if any

--- a/spec/acceptance/networkd_spec.rb
+++ b/spec/acceptance/networkd_spec.rb
@@ -42,6 +42,17 @@ describe 'systemd with manage_networkd true' do
   context 'configure systemd stopped' do
     let(:manifest) do
       <<~PUPPET
+        # Stop networkd triggering sockets first so can
+        # reach a stable state.
+        if Integer($facts['systemd_version']) >= 260 {
+          service{ [
+            'systemd-networkd-varlink.socket',
+            'systemd-networkd-varlink-metrics.socket',
+            'systemd-networkd-resolve-hook.socket' ]:
+            ensure => 'stopped',
+          }
+        }
+
         class { 'systemd':
           manage_networkd => true,
           networkd_ensure => 'stopped',


### PR DESCRIPTION
#### Pull Request (PR) description

You can only stop `systemd-networkd` if these triggering sockets are stopped upfront. In the case of systemd-networkd systemd deliberately does not stop the sockets so that reload of the service works with out destroying network connections.

For the purposes of tests we can just stop them.

