### PR TITLE
Define `systemd::resolved_package` for Ubuntu 26.04

### DIFF
--- a/data/Ubuntu-26.04.yaml
+++ b/data/Ubuntu-26.04.yaml
@@ -1,0 +1,1 @@
+systemd::resolved_package: systemd-resolved


### PR DESCRIPTION
Fixes #619.

Labeled with `skip-changelog` because #619 hasn't been included in a release yet.