### PR TITLE
Drop support for EOL Ubuntu 20.04

### DIFF
--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -36,8 +36,7 @@ define systemd::daemon_reload (
   if $enable {
     if $user {
       if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) or
-      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) or
-      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'22.04') < 0 ) {
+      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) {
         fail('systemd::daemon_reload_for a user is not supported below RedHat 9, Debian 12 or Ubuntu 22.04')
       }
 

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04",
         "24.04",
         "26.04"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -487,7 +487,7 @@ describe 'systemd' do
             is_expected.not_to contain_service('systemd-networkd').with_enable(true)
           }
 
-          if (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['full'], '20.04') >= 0) || (facts[:os]['name'] == 'Debian')
+          if facts[:os]['family'] == 'Debian'
             it { is_expected.to contain_package('systemd-timesyncd') }
           else
             it { is_expected.not_to contain_package('systemd-timesyncd') }

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -18,7 +18,7 @@ describe 'systemd::daemon_reload' do
               .with_refreshonly(true)
           end
 
-          context 'with a username specfied' do
+          context 'with a username specified' do
             let(:params) do
               { user: 'steve' }
             end
@@ -53,7 +53,7 @@ describe 'systemd::daemon_reload' do
             expect(subject).not_to contain_exec("systemd-#{title}-systemctl-daemon-reload")
           end
 
-          context 'with a username specfied' do
+          context 'with a username specified' do
             let(:params) do
               super().merge(user: 'steve')
             end

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -25,7 +25,6 @@ describe 'systemd::daemon_reload' do
 
             case [facts[:os]['name'], facts[:os]['family'], facts[:os]['release']['major']]
             when %w[Debian Debian 11],
-              ['Ubuntu', 'Debian', '20.04'],
               %w[AlmaLinux RedHat 8],
               %w[RedHat RedHat 8],
               %w[Rocky RedHat 8],


### PR DESCRIPTION
- **spec/defines/daemon_reload: Fix typo**
- **Drop support for EOL Ubuntu 20.04**
