### PR TITLE
Drop support for EOL Debian 11

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5912,7 +5912,6 @@ Struct[{
     Optional['DefaultEnvironment'] => Variant[String, Systemd::SettingEnsure],
     Optional['ManagerEnvironment'] => Variant[String, Systemd::SettingEnsure],
     Optional['DefaultCPUAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
-    Optional['DefaultBlockIOAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure], # Deprecated in v252. Delete after Debian 11 EOL
     Optional['DefaultIOAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
     Optional['DefaultIPAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
     Optional['DefaultMemoryAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],

--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -3,6 +3,5 @@ systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultIOAccounting: 'yes'
   DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -11,7 +11,6 @@ systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultIOAccounting: 'yes'
   DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
 

--- a/data/Fedora.yaml
+++ b/data/Fedora.yaml
@@ -3,6 +3,5 @@ systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultIOAccounting: 'yes'
   DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'

--- a/data/Gentoo.yaml
+++ b/data/Gentoo.yaml
@@ -3,6 +3,5 @@ systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultIOAccounting: 'yes'
   DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'

--- a/data/RedHat-family-10.yaml
+++ b/data/RedHat-family-10.yaml
@@ -3,7 +3,6 @@ systemd::oomd_package: 'systemd-oomd'
 
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
   DefaultIOAccounting: 'yes'

--- a/data/RedHat-family-8.yaml
+++ b/data/RedHat-family-8.yaml
@@ -3,7 +3,6 @@ systemd::resolved_package: ~
 
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
   DefaultIOAccounting: 'yes'

--- a/data/RedHat-family-9.yaml
+++ b/data/RedHat-family-9.yaml
@@ -3,7 +3,6 @@ systemd::oomd_package: 'systemd-oomd'
 
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
   DefaultIOAccounting: 'yes'

--- a/data/SLES-12.yaml
+++ b/data/SLES-12.yaml
@@ -1,6 +1,6 @@
 ---
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'

--- a/data/SLES-15.yaml
+++ b/data/SLES-15.yaml
@@ -1,6 +1,6 @@
 ---
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'

--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -3,7 +3,6 @@ systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultIOAccounting: 'yes'
   DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
 

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -35,8 +35,7 @@ define systemd::daemon_reload (
 
   if $enable {
     if $user {
-      if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) or
-      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) {
+      if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) {
         fail('systemd::daemon_reload_for a user is not supported below RedHat 9, Debian 12 or Ubuntu 22.04')
       }
 

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -36,7 +36,7 @@ define systemd::daemon_reload (
   if $enable {
     if $user {
       if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) {
-        fail('systemd::daemon_reload_for a user is not supported below RedHat 9, Debian 12 or Ubuntu 22.04')
+        fail('systemd::daemon_reload_for a user is not supported below RedHat 9')
       }
 
       $_title   = "${module_name}-${name}-systemctl-user-${user}-daemon-reload"

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -36,8 +36,7 @@ define systemd::daemon_reload (
   if $enable {
     if $user {
       if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) or
-      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) or
-      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'22.04') < 0 ) {
+      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) {
         fail('systemd::daemon_reload_for a user is not supported below RedHat 9, Debian 12 or Ubuntu 22.04')
       }
 

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04",
         "24.04",
         "26.04"

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11",
         "12",
         "13"
       ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -669,11 +669,11 @@ describe 'systemd' do
 
           case facts[:os]['family']
           when 'Archlinux', 'Gentoo'
-            accounting = %w[DefaultCPUAccounting DefaultIOAccounting DefaultIPAccounting DefaultBlockIOAccounting DefaultMemoryAccounting DefaultTasksAccounting]
+            accounting = %w[DefaultCPUAccounting DefaultIOAccounting DefaultIPAccounting DefaultMemoryAccounting DefaultTasksAccounting]
           when 'Debian'
-            accounting = %w[DefaultCPUAccounting DefaultBlockIOAccounting DefaultMemoryAccounting]
+            accounting = %w[DefaultCPUAccounting DefaultMemoryAccounting]
           when 'RedHat', 'Suse'
-            accounting = %w[DefaultCPUAccounting DefaultBlockIOAccounting DefaultMemoryAccounting DefaultTasksAccounting]
+            accounting = %w[DefaultCPUAccounting DefaultMemoryAccounting DefaultTasksAccounting]
           end
           accounting.each do |account|
             it { is_expected.to contain_ini_setting("system/#{account}") }
@@ -699,8 +699,8 @@ describe 'systemd' do
               is_expected.to contain_ini_setting('system/DefaultCPUAccounting').with_ensure('present').with_value('yes')
               # Ensure and value are overridden by accounting settings
               is_expected.to contain_ini_setting('system/DefaultMemoryAccounting').with_ensure('present').with_value('yes')
-              # Included by accounting (switch to DefaultIOAccounting after RHEL7 EOL)
-              is_expected.to contain_ini_setting('system/DefaultBlockIOAccounting').with_ensure('present').with_value('yes')
+              # Included by accounting
+              is_expected.to contain_ini_setting('system/DefaultIOAccounting').with_ensure('present').with_value('yes')
             }
           end
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -695,9 +695,9 @@ describe 'systemd' do
             it {
               is_expected.to compile.with_all_deps
               is_expected.to contain_ini_setting('system/DefaultTimeoutStartSec').with_ensure('present').with_value('120s')
-              # Value is overriden by accounting settings
+              # Value is overridden by accounting settings
               is_expected.to contain_ini_setting('system/DefaultCPUAccounting').with_ensure('present').with_value('yes')
-              # Ensure and value are overriden by accounting settings
+              # Ensure and value are overridden by accounting settings
               is_expected.to contain_ini_setting('system/DefaultMemoryAccounting').with_ensure('present').with_value('yes')
               # Included by accounting (switch to DefaultIOAccounting after RHEL7 EOL)
               is_expected.to contain_ini_setting('system/DefaultBlockIOAccounting').with_ensure('present').with_value('yes')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -487,7 +487,7 @@ describe 'systemd' do
             is_expected.not_to contain_service('systemd-networkd').with_enable(true)
           }
 
-          if (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['full'], '20.04') >= 0) || (facts[:os]['name'] == 'Debian')
+          if facts[:os]['family'] == 'Debian'
             it { is_expected.to contain_package('systemd-timesyncd') }
           else
             it { is_expected.not_to contain_package('systemd-timesyncd') }

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -18,7 +18,7 @@ describe 'systemd::daemon_reload' do
               .with_refreshonly(true)
           end
 
-          context 'with a username specfied' do
+          context 'with a username specified' do
             let(:params) do
               { user: 'steve' }
             end
@@ -53,7 +53,7 @@ describe 'systemd::daemon_reload' do
             expect(subject).not_to contain_exec("systemd-#{title}-systemctl-daemon-reload")
           end
 
-          context 'with a username specfied' do
+          context 'with a username specified' do
             let(:params) do
               super().merge(user: 'steve')
             end

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -23,12 +23,8 @@ describe 'systemd::daemon_reload' do
               { user: 'steve' }
             end
 
-            case [facts[:os]['name'], facts[:os]['family'], facts[:os]['release']['major']]
-            when %w[Debian Debian 11],
-              %w[AlmaLinux RedHat 8],
-              %w[RedHat RedHat 8],
-              %w[Rocky RedHat 8],
-              %w[OracleLinux RedHat 8]
+            case [facts[:os]['family'], facts[:os]['release']['major']]
+            when %w[RedHat 8]
               it { is_expected.to compile.and_raise_error(%r{user is not supported below}) }
             else
               it { is_expected.to compile }

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -25,7 +25,6 @@ describe 'systemd::daemon_reload' do
 
             case [facts[:os]['name'], facts[:os]['family'], facts[:os]['release']['major']]
             when %w[Debian Debian 11],
-              ['Ubuntu', 'Debian', '20.04'],
               %w[AlmaLinux RedHat 8],
               %w[RedHat RedHat 8],
               %w[Rocky RedHat 8],

--- a/types/servicemanagersettings.pp
+++ b/types/servicemanagersettings.pp
@@ -53,7 +53,6 @@ type Systemd::ServiceManagerSettings = Struct[
     Optional['DefaultEnvironment'] => Variant[String, Systemd::SettingEnsure],
     Optional['ManagerEnvironment'] => Variant[String, Systemd::SettingEnsure],
     Optional['DefaultCPUAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
-    Optional['DefaultBlockIOAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure], # Deprecated in v252. Delete after Debian 11 EOL
     Optional['DefaultIOAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
     Optional['DefaultIPAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],
     Optional['DefaultMemoryAccounting'] => Variant[Systemd::Boolean, Systemd::SettingEnsure],


### PR DESCRIPTION
- #626
- **spec/classes/init_spec: fix typos**
- **Drop support for EOL Debian 11**
