### PR TITLE
Add support for automount units in `manage_unit` and `manage_dropin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ class { 'systemd':
 The `systemd-coredump` system can be configured.
 
 ```puppet
-class{'systemd':
+class { 'systemd':
   manage_coredump    => true,
   coredump_backtrace => true,
   coredump_settings  => {

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1129,19 +1129,19 @@ Run systemctl daemon-reload
 ##### Force reload the system systemd
 
 ```puppet
-notify{ 'fake event to notify from':
+notify { 'fake event to notify from':
   notify => Systemd::Daemon_reload['special']
 }
-systemd::daemon_reload{ 'special': }
+systemd::daemon_reload { 'special': }
 ```
 
 ##### Force reload a systemd --user
 
 ```puppet
-notify{ 'fake event to notify from':
+notify { 'fake event to notify from':
   notify => Systemd::Daemon_reload['steve_user']
 }
-systemd::daemon_reload{ 'steve_user':
+systemd::daemon_reload { 'steve_user':
   user => 'steve',
 }
 ```
@@ -3035,7 +3035,7 @@ systemd::user_service { 'podman-auto-update.timer':
 ##### Notify a user's service to restart it
 
 ```puppet
-file{ '/home/steve/.config/systemd/user/podman-auto-update.timer':
+file { '/home/steve/.config/systemd/user/podman-auto-update.timer':
   ensure  => file,
   content => ...,
   notify  => Systemd::User_service['steve-podman-auto-update.timer']
@@ -3061,7 +3061,7 @@ systemd::user_service { 'systemd-tmpfiles-clean.timer':
 @param ensure Should the unit be started or stopped. Can only be true if user is specified.
 @param enable Should the unit be enabled, disabled or 'mask'.
 @param user User name of user whose unit should be acted upon. Mutually exclusive with
-@param global Act globally for all users. Mutually exclusibe with `user`.
+@param global Act globally for all users. Mutually exclusive with `user`.
 ```
 
 #### Parameters

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -170,6 +170,7 @@
 * [`Systemd::Unit`](#Systemd--Unit): custom datatype that validates different filenames for systemd units and unit templates
 * [`Systemd::Unit::Amount`](#Systemd--Unit--Amount): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::AmountOrPercent`](#Systemd--Unit--AmountOrPercent): Systemd definition of amount, often bytes or united bytes
+* [`Systemd::Unit::Automount`](#Systemd--Unit--Automount): Possible keys for the [Automount] section of a unit file
 * [`Systemd::Unit::Install`](#Systemd--Unit--Install): Possible keys for the [Install] section of a unit file
 * [`Systemd::Unit::Mount`](#Systemd--Unit--Mount): Possible keys for the [Mount] section of a unit file
 * [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
@@ -1762,6 +1763,7 @@ The following parameters are available in the `systemd::manage_unit` defined typ
 * [`timer_entry`](#-systemd--manage_unit--timer_entry)
 * [`path_entry`](#-systemd--manage_unit--path_entry)
 * [`socket_entry`](#-systemd--manage_unit--socket_entry)
+* [`automount_entry`](#-systemd--manage_unit--automount_entry)
 * [`mount_entry`](#-systemd--manage_unit--mount_entry)
 * [`swap_entry`](#-systemd--manage_unit--swap_entry)
 
@@ -1928,6 +1930,14 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Socket]`
 
 kev value paors for [Socket] section of the unit file.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_unit--automount_entry"></a>`automount_entry`
+
+Data type: `Optional[Systemd::Unit::Automount]`
+
+key value pairs for [Automount] section of the unit file.
 
 Default value: `undef`
 
@@ -5848,6 +5858,24 @@ Systemd definition of amount, often bytes or united bytes
   * https://www.freedesktop.org/software/systemd/man/systemd.slice.html
 
 Alias of `Variant[Systemd::Unit::Amount, Systemd::Unit::Percent]`
+
+### <a name="Systemd--Unit--Automount"></a>`Systemd::Unit::Automount`
+
+Possible keys for the [Automount] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/latest/systemd.automount.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Where'] => Stdlib::Absolutepath,
+    Optional['ExtraOptions'] => String[1],
+    Optional['DirectoryMode'] => Stdlib::Filemode,
+    Optional['TimeoutIdleSec'] => Systemd::Timespan,
+  }]
+```
 
 ### <a name="Systemd--Unit--Install"></a>`Systemd::Unit::Install`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1617,7 +1617,7 @@ systemd::manage_unit { 'myrunner.service':
 }
 ```
 
-##### Genenerate a path unit
+##### Generate a path unit
 
 ```puppet
 systemd::manage_unit { 'passwd-mon.path':
@@ -1638,7 +1638,7 @@ systemd::manage_unit { 'passwd-mon.path':
 ##### Generate a socket and service (xinetd style)
 
 ```puppet
-systemd::manage_unit {'arcd.socket':
+systemd::manage_unit { 'arcd.socket':
   ensure        => 'present',
   unit_entry    => {
     'Description' => 'arcd.service',
@@ -1653,7 +1653,7 @@ systemd::manage_unit {'arcd.socket':
   },
 }
 
-systemd::manage_unit{'arcd@.service':
+systemd::manage_unit { 'arcd@.service':
   ensure        => 'present',
   enable        => true,
   active        => true,
@@ -1696,7 +1696,7 @@ systemd::manage_dropin { 'tmpfs-db.conf':
 
 ```puppet
 
-systemd::manage_unit{'swapfile.swap':
+systemd::manage_unit { 'swapfile.swap':
   ensure        => present,
   enable        => true,
   active        => true,
@@ -1713,7 +1713,7 @@ systemd::manage_unit{'swapfile.swap':
   },
   require       => Systemd::Manage_unit['mkswap.service'],
 }
-systemd::manage_unit{'mkswap.service':
+systemd::manage_unit { 'mkswap.service':
   ensure        => present,
   unit_entry    => {
     'Description'         => 'Format a swapfile at /swapfile',
@@ -1929,7 +1929,7 @@ Default value: `undef`
 
 Data type: `Optional[Systemd::Unit::Socket]`
 
-kev value paors for [Socket] section of the unit file.
+kev value pairs for [Socket] section of the unit file.
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1430,6 +1430,7 @@ The following parameters are available in the `systemd::manage_dropin` defined t
 * [`timer_entry`](#-systemd--manage_dropin--timer_entry)
 * [`path_entry`](#-systemd--manage_dropin--path_entry)
 * [`socket_entry`](#-systemd--manage_dropin--socket_entry)
+* [`automount_entry`](#-systemd--manage_dropin--automount_entry)
 * [`mount_entry`](#-systemd--manage_dropin--mount_entry)
 * [`swap_entry`](#-systemd--manage_dropin--swap_entry)
 
@@ -1572,6 +1573,14 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Socket]`
 
 key value pairs for the [Socket] section of the unit file
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_dropin--automount_entry"></a>`automount_entry`
+
+Data type: `Optional[Systemd::Unit::Automount]`
+
+key value pairs for the [Automount] section of the unit file
 
 Default value: `undef`
 

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -14,16 +14,16 @@
 #   Ubuntu 22.04 or Debian 12.
 #
 # @example Force reload the system systemd
-#   notify{ 'fake event to notify from':
+#   notify { 'fake event to notify from':
 #     notify => Systemd::Daemon_reload['special']
 #   }
-#   systemd::daemon_reload{ 'special': }
+#   systemd::daemon_reload { 'special': }
 #
 # @example Force reload a systemd --user
-#   notify{ 'fake event to notify from':
+#   notify { 'fake event to notify from':
 #     notify => Systemd::Daemon_reload['steve_user']
 #   }
-#   systemd::daemon_reload{ 'steve_user':
+#   systemd::daemon_reload { 'steve_user':
 #     user => 'steve',
 #   }
 #

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -88,6 +88,7 @@
 # @param timer_entry key value pairs for [Timer] section of the unit file
 # @param path_entry key value pairs for [Path] section of the unit file
 # @param socket_entry key value pairs for the [Socket] section of the unit file
+# @param automount_entry key value pairs for the [Automount] section of the unit file
 # @param mount_entry key value pairs for the [Mount] section of the unit file
 # @param swap_entry key value pairs for the [Swap] section of the unit file
 #
@@ -110,6 +111,7 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Timer]   $timer_entry             = undef,
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
+  Optional[Systemd::Unit::Automount] $automount_entry       = undef,
   Optional[Systemd::Unit::Mount]   $mount_entry             = undef,
   Optional[Systemd::Unit::Swap]    $swap_entry              = undef,
 ) {
@@ -127,6 +129,10 @@ define systemd::manage_dropin (
 
   if $slice_entry and $unit !~ Pattern['^[^/]+\.slice'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} slice_entry is only valid for slice units")
+  }
+
+  if $automount_entry and $unit !~ Pattern['^[^/]+\.automount'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} automount_entry is only valid for automount units")
   }
 
   if $mount_entry and $unit !~ Pattern['^[^/]+\.mount'] {
@@ -151,15 +157,16 @@ define systemd::manage_dropin (
     daemon_reload           => $daemon_reload,
     content                 => epp('systemd/unit_file.epp',
       {
-        'unit_entry'    => $unit_entry,
-        'slice_entry'   => $slice_entry,
-        'service_entry' => $service_entry,
-        'install_entry' => $install_entry,
-        'timer_entry'   => $timer_entry,
-        'path_entry'    => $path_entry,
-        'socket_entry'  => $socket_entry,
-        'mount_entry'   => $mount_entry,
-        'swap_entry'    => $swap_entry,
+        'unit_entry'      => $unit_entry,
+        'slice_entry'     => $slice_entry,
+        'service_entry'   => $service_entry,
+        'install_entry'   => $install_entry,
+        'timer_entry'     => $timer_entry,
+        'path_entry'      => $path_entry,
+        'socket_entry'    => $socket_entry,
+        'automount_entry' => $automount_entry,
+        'mount_entry'     => $mount_entry,
+        'swap_entry'      => $swap_entry,
       },
     ),
   }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -152,6 +152,7 @@
 # @param timer_entry key value pairs for [Timer] section of the unit file
 # @param path_entry key value pairs for [Path] section of the unit file.
 # @param socket_entry kev value paors for [Socket] section of the unit file.
+# @param automount_entry key value pairs for [Automount] section of the unit file.
 # @param mount_entry kev value pairs for [Mount] section of the unit file.
 # @param swap_entry kev value pairs for [Swap] section of the unit file.
 #
@@ -176,6 +177,7 @@ define systemd::manage_unit (
   Optional[Systemd::Unit::Timer]           $timer_entry             = undef,
   Optional[Systemd::Unit::Path]            $path_entry              = undef,
   Optional[Systemd::Unit::Socket]          $socket_entry            = undef,
+  Optional[Systemd::Unit::Automount]       $automount_entry         = undef,
   Optional[Systemd::Unit::Mount]           $mount_entry             = undef,
   Optional[Systemd::Unit::Swap]            $swap_entry              = undef,
 ) {
@@ -195,6 +197,10 @@ define systemd::manage_unit (
 
   if $slice_entry and $name !~ Pattern['^[^/]+\.slice'] {
     fail("Systemd::Manage_unit[${name}]: slice_entry is only valid for slice units")
+  }
+
+  if $automount_entry and $name !~ Pattern['^[^/]+\.automount'] {
+    fail("Systemd::Manage_unit[${name}]: automount_entry is only valid for automount units")
   }
 
   if $mount_entry and $name !~ Pattern['^[^/]+\.mount'] {
@@ -224,15 +230,16 @@ define systemd::manage_unit (
     service_restart         => $service_restart,
     content                 => epp('systemd/unit_file.epp',
       {
-        'unit_entry'    => $unit_entry,
-        'slice_entry'   => $slice_entry,
-        'service_entry' => $service_entry,
-        'install_entry' => $install_entry,
-        'timer_entry'   => $timer_entry,
-        'path_entry'    => $path_entry,
-        'socket_entry'  => $socket_entry,
-        'mount_entry'   => $mount_entry,
-        'swap_entry'    => $swap_entry,
+        'unit_entry'      => $unit_entry,
+        'slice_entry'     => $slice_entry,
+        'service_entry'   => $service_entry,
+        'install_entry'   => $install_entry,
+        'timer_entry'     => $timer_entry,
+        'path_entry'      => $path_entry,
+        'socket_entry'    => $socket_entry,
+        'automount_entry' => $automount_entry,
+        'mount_entry'     => $mount_entry,
+        'swap_entry'      => $swap_entry,
       },
     ),
   }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -18,7 +18,7 @@
 #     },
 #   }
 #
-# @example Genenerate a path unit
+# @example Generate a path unit
 #   systemd::manage_unit { 'passwd-mon.path':
 #     ensure        => present,
 #     unit_entry    => {
@@ -34,7 +34,7 @@
 #   }
 #
 # @example Generate a socket and service (xinetd style)
-#  systemd::manage_unit {'arcd.socket':
+#  systemd::manage_unit { 'arcd.socket':
 #    ensure        => 'present',
 #    unit_entry    => {
 #      'Description' => 'arcd.service',
@@ -49,7 +49,7 @@
 #    },
 #  }
 #
-#  systemd::manage_unit{'arcd@.service':
+#  systemd::manage_unit { 'arcd@.service':
 #    ensure        => 'present',
 #    enable        => true,
 #    active        => true,
@@ -86,7 +86,7 @@
 #
 # @example Create and Mount a Swap File
 #
-#  systemd::manage_unit{'swapfile.swap':
+#  systemd::manage_unit { 'swapfile.swap':
 #    ensure        => present,
 #    enable        => true,
 #    active        => true,
@@ -103,7 +103,7 @@
 #    },
 #    require       => Systemd::Manage_unit['mkswap.service'],
 #  }
-#  systemd::manage_unit{'mkswap.service':
+#  systemd::manage_unit { 'mkswap.service':
 #    ensure        => present,
 #    unit_entry    => {
 #      'Description'         => 'Format a swapfile at /swapfile',
@@ -151,7 +151,7 @@
 # @param install_entry key value pairs for [Install] section of the unit file.
 # @param timer_entry key value pairs for [Timer] section of the unit file
 # @param path_entry key value pairs for [Path] section of the unit file.
-# @param socket_entry kev value paors for [Socket] section of the unit file.
+# @param socket_entry kev value pairs for [Socket] section of the unit file.
 # @param automount_entry key value pairs for [Automount] section of the unit file.
 # @param mount_entry kev value pairs for [Mount] section of the unit file.
 # @param swap_entry kev value pairs for [Swap] section of the unit file.

--- a/manifests/user_service.pp
+++ b/manifests/user_service.pp
@@ -17,7 +17,7 @@
 #  }
 #
 # @example Notify a user's service to restart it
-#  file{ '/home/steve/.config/systemd/user/podman-auto-update.timer':
+#  file { '/home/steve/.config/systemd/user/podman-auto-update.timer':
 #    ensure  => file,
 #    content => ...,
 #    notify  => Systemd::User_service['steve-podman-auto-update.timer']
@@ -40,7 +40,7 @@
 #  @param ensure Should the unit be started or stopped. Can only be true if user is specified.
 #  @param enable Should the unit be enabled, disabled or 'mask'.
 #  @param user User name of user whose unit should be acted upon. Mutually exclusive with
-#  @param global Act globally for all users. Mutually exclusibe with `user`.
+#  @param global Act globally for all users. Mutually exclusive with `user`.
 #
 define systemd::user_service (
   Systemd::Unit $unit = $title,

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -99,6 +99,45 @@ describe 'systemd::manage_unit' do
           end
         end
 
+        context 'on an automount' do
+          let(:title) { 'some-dir.automount' }
+
+          let(:params) do
+            {
+              unit_entry: {
+                Description: 'Automount /some/dir',
+              },
+              automount_entry: {
+                'Where' => '/some/dir',
+                'TimeoutIdleSec' => '5min 20s',
+              },
+              install_entry: {
+                WantedBy: 'multi-user.target',
+              },
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+
+            is_expected.to contain_systemd__unit_file('some-dir.automount')
+              .with_content(<<~CONTENT)
+                # Deployed with puppet
+                #
+
+                [Unit]
+                Description=Automount /some/dir
+
+                [Automount]
+                Where=/some/dir
+                TimeoutIdleSec=5min 20s
+
+                [Install]
+                WantedBy=multi-user.target
+              CONTENT
+          end
+        end
+
         context 'on a mount' do
           let(:title) { 'var-lib-sss-db.mount' }
 

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -26,7 +26,7 @@
    'Install',
 ]
 
-# Directives which are pair of items to be expressed as a space seperated pair.
+# Directives which are pair of items to be expressed as a space separated pair.
 $_tupled_values = [
   'IODeviceWeight',
   'IOReadBandwidthMax',

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -6,6 +6,7 @@
  Optional[Hash] $timer_entry,
  Optional[Hash] $path_entry,
  Optional[Hash] $socket_entry,
+ Optional[Hash] $automount_entry,
  Optional[Hash] $mount_entry,
  Optional[Hash] $swap_entry,
 | -%>
@@ -21,6 +22,7 @@
    'Timer',
    'Path',
    'Socket',
+   'Automount',
    'Mount',
    'Swap',
    'Install',

--- a/types/unit/automount.pp
+++ b/types/unit/automount.pp
@@ -1,0 +1,10 @@
+# @summary Possible keys for the [Automount] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/latest/systemd.automount.html
+type Systemd::Unit::Automount = Struct[
+  {
+    Optional['Where'] => Stdlib::Absolutepath,
+    Optional['ExtraOptions'] => String[1],
+    Optional['DirectoryMode'] => Stdlib::Filemode,
+    Optional['TimeoutIdleSec'] => Systemd::Timespan,
+  }
+]


### PR DESCRIPTION
This adds support for automount unit files in `manage_unit` and `manage_dropin`.

This also has a few commits for cleaning up typos and whitespace style in the docs.