### PR TITLE
Add type and wrapper for purging unit files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,54 @@ systemd::manage_units:
       CPUWeight: 2000
 ```
 
+#### purging previously managed unit files
+
+After removing any `systemd::manage_unit` definitions from your manifests, by default, the unit files installed will remain on your system.
+If you wish to remove them automatically, this module can help with that.
+
+Only unit files written by `systemd::manage_unit` are eligible for purging: they are identified by the `# Deployed with puppet` header that the module writes as the first line of every unit file. Hand-written unit files and symlinks (such as systemd enablement links) are never touched.
+
+You can either...
+
+Purge all previously managed units in `/etc/systemd/system`, and reload the systemd daemon...
+
+```puppet
+include systemd::purge_units
+```
+
+Declare the class with custom options such as custom paths, the unit types to consider, and the `daemon_reload` setting.
+
+```puppet
+class { 'systemd::purge_units':
+  paths         => [
+    '/path/to/custom/unit/dir1',
+    '/path/to/custom/unit/dir2',
+  ],
+  unit_types    => ['service', 'timer'],
+  daemon_reload => false,
+}
+```
+
+You can also include the functionality through the `systemd` base class `purge_units` parameter. For example, you could do this via hiera.
+
+```yaml
+systemd::purge_units: true
+```
+
+or...
+
+```yaml
+systemd::purge_units: ['/custom/path']
+```
+
+If you need full flexibility, you can declare the `systemd_purge_units` type in your manifests directly.
+
+```puppet
+systemd_purge_units { '/etc/systemd/system':
+  unit_types => ['service', 'timer'],
+}
+```
+
 ### drop-in files
 
 Drop-in files are used to add or alter settings of a unit without modifying the

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,7 @@
 #### Public Classes
 
 * [`systemd`](#systemd): This module allows triggering systemd commands once for all modules
+* [`systemd::purge_units`](#systemd--purge_units): Purges previously managed `systemd::manage_unit` units
 * [`systemd::sysusers`](#systemd--sysusers): Prepare systemd sysusers files
 * [`systemd::tmpfiles`](#systemd--tmpfiles): Update the systemd temp files
 
@@ -50,6 +51,7 @@
 ### Resource types
 
 * [`loginctl_user`](#loginctl_user): An arbitrary name used as the identity of the resource.
+* [`systemd_purge_units`](#systemd_purge_units): This is a metatype to purge unmanaged systemd units that were previously created with the `systemd::manage_unit` defined type.  Set the name 
 
 ### Functions
 
@@ -275,6 +277,7 @@ The following parameters are available in the `systemd` class:
 * [`loginctl_users`](#-systemd--loginctl_users)
 * [`dropin_files`](#-systemd--dropin_files)
 * [`manage_units`](#-systemd--manage_units)
+* [`purge_units`](#-systemd--purge_units)
 * [`manage_dropins`](#-systemd--manage_dropins)
 * [`manage_all_network_files`](#-systemd--manage_all_network_files)
 * [`network_path`](#-systemd--network_path)
@@ -914,6 +917,17 @@ Configure units via hiera and `systemd::manage_unit` with factory pattern
 
 Default value: `{}`
 
+##### <a name="-systemd--purge_units"></a>`purge_units`
+
+Data type: `Variant[Boolean, Array[Stdlib::Absolutepath, 1]]`
+
+When set to `true` will include `systemd::purge_units` with default options including the default systemd::manage_units path.
+This will purge any previously managed systemd units created with `systemd::manage_unit`, (or the `manage_units` parameter from this base class.)
+Can also be set to an array of paths if you have `systemd::manage_unit` resources using either the non-default path, or more than one path.
+For finer control (such as restricting which unit types are purged) declare `systemd::purge_units` or `systemd_purge_units` directly.
+
+Default value: `false`
+
 ##### <a name="-systemd--manage_dropins"></a>`manage_dropins`
 
 Data type: `Stdlib::CreateResources`
@@ -1072,6 +1086,57 @@ Data type: `Boolean`
 If true, the util-linux package is installed, for runuser command.
 
 Default value: `false`
+
+### <a name="systemd--purge_units"></a>`systemd::purge_units`
+
+Unit files inside `$paths` whose first line is the `# Deployed with puppet` header
+will be removed if they aren't currently being managed by puppet.
+
+#### Parameters
+
+The following parameters are available in the `systemd::purge_units` class:
+
+* [`daemon_reload`](#-systemd--purge_units--daemon_reload)
+* [`paths`](#-systemd--purge_units--paths)
+* [`unit_types`](#-systemd--purge_units--unit_types)
+
+##### <a name="-systemd--purge_units--daemon_reload"></a>`daemon_reload`
+
+Data type: `Boolean`
+
+Whether to reload the systemd daemon after purging units
+
+Default value: `true`
+
+##### <a name="-systemd--purge_units--paths"></a>`paths`
+
+Data type: `Array[Stdlib::Absolutepath, 1]`
+
+The path(s) to your systemd units.
+
+Default value: `['/etc/systemd/system']`
+
+##### <a name="-systemd--purge_units--unit_types"></a>`unit_types`
+
+Data type: `Array[Enum['automount', 'mount', 'path', 'service', 'slice', 'socket', 'swap', 'timer'], 1]`
+
+The unit file types to purge. Defaults to every type that `systemd::manage_unit` can create.
+Restrict this if you only want certain unit types purged.
+
+Default value:
+
+```puppet
+[
+    'automount',
+    'mount',
+    'path',
+    'service',
+    'slice',
+    'socket',
+    'swap',
+    'timer',
+  ]
+```
 
 ### <a name="systemd--sysusers"></a>`systemd::sysusers`
 
@@ -3158,6 +3223,44 @@ An arbitrary name used as the identity of the resource.
 
 The specific backend to use for this `loginctl_user` resource. You will seldom need to specify this --- Puppet will
 usually discover the appropriate provider for your platform.
+
+### <a name="systemd_purge_units"></a>`systemd_purge_units`
+
+This is a metatype to purge unmanaged systemd units that were previously created with the `systemd::manage_unit` defined type.
+
+Set the name of the resource to your systemd unit file path. (eg. `/etc/systemd/system`).
+Any unmanaged unit files in that directory whose first line is `# Deployed with puppet` will be removed.
+By default all unit types that `systemd::manage_unit` can create are considered, but this can be narrowed with the `unit_types` parameter.
+
+#### Properties
+
+The following properties are available in the `systemd_purge_units` type.
+
+##### `ensure`
+
+Valid values: `purgable`, `purged`
+
+The basic property that the resource should be in.
+
+Default value: `purged`
+
+#### Parameters
+
+The following parameters are available in the `systemd_purge_units` type.
+
+* [`path`](#-systemd_purge_units--path)
+* [`unit_types`](#-systemd_purge_units--unit_types)
+
+##### <a name="-systemd_purge_units--path"></a>`path`
+
+The fully qualified directory to purge unit files from.
+
+##### <a name="-systemd_purge_units--unit_types"></a>`unit_types`
+
+The unit file types to purge. Defaults to every type that `systemd::manage_unit` can create.
+Give an array to restrict purging to specific types, eg. `['service', 'timer']`.
+
+Default value: `valid_unit_types`
 
 ## Functions
 

--- a/lib/puppet/type/systemd_purge_units.rb
+++ b/lib/puppet/type/systemd_purge_units.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+Puppet::Type.newtype(:systemd_purge_units) do
+  attr_reader :purged_units
+
+  # The unit file types that `systemd::manage_unit` is able to create. Every unit
+  # file it writes starts with the `# Deployed with puppet` header, so any of
+  # these extensions are safe to purge.
+  valid_unit_types = %w[
+    automount
+    mount
+    path
+    service
+    slice
+    socket
+    swap
+    timer
+  ].freeze
+
+  @doc = <<-EOT
+  This is a metatype to purge unmanaged systemd units that were previously created with the `systemd::manage_unit` defined type.
+
+  Set the name of the resource to your systemd unit file path. (eg. `/etc/systemd/system`).
+  Any unmanaged unit files in that directory whose first line is `# Deployed with puppet` will be removed.
+  By default all unit types that `systemd::manage_unit` can create are considered, but this can be narrowed with the `unit_types` parameter.
+  EOT
+
+  # Similar to crayfishx/purge, this ensurable block is here to make sure _this_ resource
+  # enters a changed state when there are any generated resources that have been purged.
+  ensurable do
+    defaultto(:purged)
+    newvalue(:purgable)
+    newvalue(:purged) do
+      true
+    end
+
+    def retrieve
+      if @resource.purged?
+        :purgable
+      else
+        :purged
+      end
+    end
+  end
+
+  newparam(:path, namevar: true) do
+    desc 'The fully qualified directory to purge unit files from.'
+
+    validate do |value|
+      raise ArgumentError, 'path must be fully qualified.' unless Puppet::Util.absolute_path?(value, :posix)
+    end
+  end
+
+  newparam(:unit_types) do
+    desc <<-EOT
+      The unit file types to purge. Defaults to every type that `systemd::manage_unit` can create.
+      Give an array to restrict purging to specific types, eg. `['service', 'timer']`.
+    EOT
+
+    defaultto(valid_unit_types)
+
+    munge { |value| Array(value) }
+
+    validate do |value|
+      Array(value).each do |type|
+        raise ArgumentError, "unit_types must be one of #{valid_unit_types.join(', ')}; got '#{type}'" unless valid_unit_types.include?(type)
+      end
+    end
+  end
+
+  def generate
+    @purged_units = []
+
+    unless File.directory?(self[:path])
+      warning("#{self[:path]} does not exist or is not a directory; nothing to purge")
+      return @purged_units
+    end
+
+    dir = normalize_path(self[:path])
+    extensions = Array(self[:unit_types]).map { |type| ".#{type}" }
+
+    Dir.foreach(dir) do |entry|
+      file_path = normalize_path(File.join(dir, entry))
+
+      # Skip symlinks (eg. systemd enablement links) so we never follow or remove them.
+      next if File.symlink?(file_path)
+      next unless File.file?(file_path)
+      next unless extensions.include?(File.extname(entry))
+      next unless contains_puppet_header?(file_path)
+      next if in_catalog?(file_path)
+
+      debug "systemd unit #{entry} was not in catalog and will be purged from #{dir}"
+
+      file_opts = {
+        ensure: :absent,
+        path: file_path,
+      }
+
+      # Copy Systemd_purge_units resource metaparameters into generated File resources.
+      # :alias is excluded because copying it onto more than one File would raise a
+      # duplicate alias error.
+      Puppet::Type.metaparams.each do |metaparam|
+        next if metaparam == :alias
+
+        file_opts[metaparam] = self[metaparam] unless self[metaparam].nil?
+      end
+
+      @purged_units << Puppet::Type.type(:file).new(file_opts)
+    end
+
+    @purged_units
+  end
+
+  # Returns true if the first line of the file is the puppet header. Only the
+  # first line is read so this stays cheap on large unit files.
+  def contains_puppet_header?(file)
+    first_line = File.open(file, &:gets)
+    !first_line.nil? && first_line.start_with?('# Deployed with puppet')
+  end
+
+  def in_catalog?(file)
+    managed_files.include?(file)
+  end
+
+  # Returns array of (normalized) file paths of all File resources in the catalog
+  def managed_files
+    @managed_files ||= catalog.resources.filter_map do |resource|
+      next unless resource.is_a?(Puppet::Type.type(:file))
+
+      normalize_path(resource[:path])
+    end
+  end
+
+  # Lexically normalize a path (collapse `//`, strip trailing slashes, resolve `.`/`..`)
+  # so comparisons against catalog paths are robust to formatting differences.
+  def normalize_path(path)
+    Pathname.new(path).cleanpath.to_s
+  end
+
+  def purged?
+    Array(@purged_units).any?
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -251,6 +251,12 @@
 # @param manage_units
 #   Configure units via hiera and `systemd::manage_unit` with factory pattern
 #
+# @param purge_units
+#   When set to `true` will include `systemd::purge_units` with default options including the default systemd::manage_units path.
+#   This will purge any previously managed systemd units created with `systemd::manage_unit`, (or the `manage_units` parameter from this base class.)
+#   Can also be set to an array of paths if you have `systemd::manage_unit` resources using either the non-default path, or more than one path.
+#   For finer control (such as restricting which unit types are purged) declare `systemd::purge_units` or `systemd_purge_units` directly.
+#
 # @param manage_dropins
 #   Configure dropin files via hiera and `systemd::manage_dropin` with factory pattern
 #
@@ -391,6 +397,7 @@ class systemd (
   Stdlib::CreateResources                             $loginctl_users = {},
   Stdlib::CreateResources                             $dropin_files = {},
   Stdlib::CreateResources                             $manage_units = {},
+  Variant[Boolean, Array[Stdlib::Absolutepath, 1]]    $purge_units = false,
   Stdlib::CreateResources                             $manage_dropins = {},
   Stdlib::CreateResources                             $udev_rules = {},
   Boolean                                             $manage_coredump = false,
@@ -508,6 +515,14 @@ class systemd (
   $manage_units.each |$name, $resource| {
     systemd::manage_unit { $name:
       * => $resource,
+    }
+  }
+
+  if $purge_units {
+    if $purge_units =~ Array {
+      class { 'systemd::purge_units': paths => $purge_units }
+    } else {
+      include systemd::purge_units
     }
   }
 

--- a/manifests/purge_units.pp
+++ b/manifests/purge_units.pp
@@ -1,0 +1,36 @@
+# @summary Purges previously managed `systemd::manage_unit` units
+#
+# Unit files inside `$paths` whose first line is the `# Deployed with puppet` header
+# will be removed if they aren't currently being managed by puppet.
+#
+# @param daemon_reload
+#   Whether to reload the systemd daemon after purging units
+# @param paths
+#   The path(s) to your systemd units.
+# @param unit_types
+#   The unit file types to purge. Defaults to every type that `systemd::manage_unit` can create.
+#   Restrict this if you only want certain unit types purged.
+class systemd::purge_units (
+  Boolean                        $daemon_reload = true,
+  Array[Stdlib::Absolutepath, 1] $paths         = ['/etc/systemd/system'],
+  Array[Enum['automount', 'mount', 'path', 'service', 'slice', 'socket', 'swap', 'timer'], 1] $unit_types = [
+    'automount',
+    'mount',
+    'path',
+    'service',
+    'slice',
+    'socket',
+    'swap',
+    'timer',
+  ],
+) {
+  systemd_purge_units { $paths:
+    unit_types => $unit_types,
+  }
+
+  if $daemon_reload {
+    systemd::daemon_reload { 'purge_units':
+      subscribe => Systemd_purge_units[$paths],
+    }
+  }
+}

--- a/spec/acceptance/purge_units_spec.rb
+++ b/spec/acceptance/purge_units_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+SERVICE_FILE = '/etc/systemd/system/purgetest.service'
+TIMER_FILE   = '/etc/systemd/system/purgetest.timer'
+FOREIGN_FILE = '/etc/systemd/system/foreign.service'
+
+describe 'systemd::purge_units' do
+  # Deploys two units (a service and a timer) with systemd::manage_unit.
+  let(:manage_manifest) do
+    <<~PUPPET
+      systemd::manage_unit { 'purgetest.service':
+        unit_entry    => { 'Description' => 'Purge test service' },
+        service_entry => { 'Type' => 'oneshot', 'ExecStart' => '/bin/true' },
+        install_entry => { 'WantedBy' => 'multi-user.target' },
+      }
+
+      systemd::manage_unit { 'purgetest.timer':
+        unit_entry    => { 'Description' => 'Purge test timer' },
+        timer_entry   => { 'OnCalendar' => 'daily' },
+        install_entry => { 'WantedBy' => 'timers.target' },
+      }
+    PUPPET
+  end
+
+  context 'when previously managed units are removed from the catalog' do
+    # The manage_unit resources have been removed and purging is enabled instead.
+    let(:purge_manifest) do
+      <<~PUPPET
+        class { 'systemd':
+          purge_units => true,
+        }
+      PUPPET
+    end
+
+    context 'after deploying the units' do
+      it 'is idempotent and leaves a hand-written unit in place' do
+        # A hand-written unit file with no puppet header. It must never be purged.
+        create_remote_file(default, FOREIGN_FILE, "[Unit]\nDescription=not deployed with puppet\n")
+        apply_manifest(manage_manifest, catch_failures: true)
+        apply_manifest(manage_manifest, catch_changes: true)
+      end
+
+      describe file(SERVICE_FILE) do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{\A# Deployed with puppet}) }
+      end
+
+      describe file(TIMER_FILE) do
+        it { is_expected.to be_file }
+      end
+    end
+
+    context 'after the units are purged' do
+      it 'is idempotent' do
+        apply_manifest(purge_manifest, catch_failures: true)
+        apply_manifest(purge_manifest, catch_changes: true)
+      end
+
+      describe file(SERVICE_FILE) do
+        it('the purged service no longer exists') { is_expected.not_to exist }
+      end
+
+      describe file(TIMER_FILE) do
+        it('the purged timer no longer exists') { is_expected.not_to exist }
+      end
+
+      describe file(FOREIGN_FILE) do
+        it { is_expected.to be_file }
+      end
+    end
+  end
+
+  context 'when restricting the unit types to purge' do
+    # Only purge services, leaving timers in place.
+    let(:restricted_manifest) do
+      <<~PUPPET
+        class { 'systemd::purge_units':
+          unit_types => ['service'],
+        }
+      PUPPET
+    end
+
+    it 'redeploys the units then purges only services, idempotently' do
+      apply_manifest(manage_manifest, catch_failures: true)
+      apply_manifest(restricted_manifest, catch_failures: true)
+      apply_manifest(restricted_manifest, catch_changes: true)
+    end
+
+    describe file(SERVICE_FILE) do
+      it { is_expected.not_to exist }
+    end
+
+    describe file(TIMER_FILE) do
+      it { is_expected.to be_file }
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1132,6 +1132,32 @@ describe 'systemd' do
           }
         end
 
+        describe '`purge_units` parameter' do
+          context 'by default' do
+            it { is_expected.not_to contain_class('systemd::purge_units') }
+          end
+
+          context 'when `purge_units` is `true`' do
+            let(:params) do
+              {
+                purge_units: true,
+              }
+            end
+
+            it { is_expected.to contain_class('systemd::purge_units').with_paths(['/etc/systemd/system']) }
+          end
+
+          context 'when `purge_units` is an array of paths' do
+            let(:params) do
+              {
+                purge_units: ['/path1', '/path2'],
+              }
+            end
+
+            it { is_expected.to contain_class('systemd::purge_units').with_paths(['/path1', '/path2']) }
+          end
+        end
+
         context 'when passing manage_dropins' do
           let(:params) do
             {

--- a/spec/classes/purge_units_spec.rb
+++ b/spec/classes/purge_units_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::purge_units' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_systemd_purge_units('/etc/systemd/system').with_unit_types(%w[automount mount path service slice socket swap timer]) }
+      it { is_expected.to contain_systemd__daemon_reload('purge_units') }
+
+      context 'with custom unit_types' do
+        let(:params) do
+          {
+            unit_types: %w[service timer],
+          }
+        end
+
+        it { is_expected.to contain_systemd_purge_units('/etc/systemd/system').with_unit_types(%w[service timer]) }
+      end
+
+      context 'with custom paths' do
+        let(:params) do
+          {
+            paths: ['/path1', '/path2'],
+          }
+        end
+
+        it { is_expected.to contain_systemd_purge_units('/path1').that_notifies('Systemd::Daemon_reload[purge_units]') }
+        it { is_expected.to contain_systemd_purge_units('/path2').that_notifies('Systemd::Daemon_reload[purge_units]') }
+
+        it { is_expected.to have_systemd_purge_units_resource_count(2) }
+      end
+
+      context 'with `daemon_reload` false' do
+        let(:params) do
+          {
+            daemon_reload: false,
+          }
+        end
+
+        it { is_expected.to contain_systemd_purge_units('/etc/systemd/system') }
+        it { is_expected.not_to contain_systemd__daemon_reload('purge_units') }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/systemd_purge_units_spec.rb
+++ b/spec/unit/puppet/type/systemd_purge_units_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+systemd_purge_units = Puppet::Type.type(:systemd_purge_units)
+
+describe systemd_purge_units do
+  let(:dir) { Dir.mktmpdir('systemd_purge_units') }
+
+  after do
+    FileUtils.remove_entry(dir)
+  end
+
+  # Write a file in the purge directory, optionally with the puppet header as its first line.
+  def write_unit(dir, name, header: true, body: "[Unit]\nDescription=test\n")
+    content = +''
+    content << "# Deployed with puppet\n" if header
+    content << body
+    path = File.join(dir, name)
+    File.write(path, content)
+    path
+  end
+
+  # Build a catalog containing the purge resource plus any pre-existing (managed) File resources.
+  def generate_for(resource, managed_paths: [])
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource(resource)
+    managed_paths.each do |path|
+      catalog.add_resource(Puppet::Type.type(:file).new(path: path, ensure: :present))
+    end
+    resource.generate || []
+  end
+
+  # The paths the resource would purge, as plain strings.
+  def purged_paths(resource, **kwargs)
+    generate_for(resource, **kwargs).map { |file| file[:path] }
+  end
+
+  describe 'parameter validation' do
+    it 'requires path to be absolute' do
+      expect { described_class.new(path: 'relative/path') }.to raise_error(Puppet::Error, %r{path must be fully qualified})
+    end
+
+    it 'accepts an absolute path' do
+      expect { described_class.new(path: '/etc/systemd/system') }.not_to raise_error
+    end
+
+    it 'defaults unit_types to all eight manage_unit types' do
+      resource = described_class.new(path: '/etc/systemd/system')
+      expect(resource[:unit_types]).to contain_exactly('automount', 'mount', 'path', 'service', 'slice', 'socket', 'swap', 'timer')
+    end
+
+    it 'accepts a restricted list of unit_types' do
+      resource = described_class.new(path: '/etc/systemd/system', unit_types: ['service'])
+      expect(resource[:unit_types]).to eq(['service'])
+    end
+
+    it 'rejects an unknown unit type' do
+      expect { described_class.new(path: '/etc/systemd/system', unit_types: ['bogus']) }.to raise_error(Puppet::Error, %r{unit_types must be one of})
+    end
+  end
+
+  describe '#generate' do
+    it 'purges unmanaged unit files carrying the puppet header' do
+      write_unit(dir, 'orphan.service')
+      write_unit(dir, 'orphan.timer')
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource)).to contain_exactly(
+        File.join(dir, 'orphan.service'),
+        File.join(dir, 'orphan.timer'),
+      )
+    end
+
+    it 'purges every unit type manage_unit can create by default' do
+      %w[automount mount path service slice socket swap timer].each do |type|
+        write_unit(dir, "orphan.#{type}")
+      end
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource).length).to eq(8)
+    end
+
+    it 'generates File resources with ensure => absent' do
+      write_unit(dir, 'orphan.service')
+
+      resource = described_class.new(path: dir)
+      generated = generate_for(resource)
+      expect(generated).to all(be_a(Puppet::Type.type(:file)))
+      expect(generated.map { |f| f[:ensure] }).to all(eq(:absent))
+    end
+
+    it 'does not purge files that are managed in the catalog' do
+      managed = write_unit(dir, 'managed.service')
+      write_unit(dir, 'orphan.service')
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource, managed_paths: [managed])).to contain_exactly(File.join(dir, 'orphan.service'))
+    end
+
+    it 'normalizes paths so a trailing slash does not orphan a managed file' do
+      managed = write_unit(dir, 'managed.service')
+
+      # Resource path has a trailing slash; catalog path does not.
+      resource = described_class.new(path: "#{dir}/")
+      expect(purged_paths(resource, managed_paths: [managed])).to be_empty
+    end
+
+    it 'ignores files without the puppet header' do
+      write_unit(dir, 'foreign.service', header: false)
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource)).to be_empty
+    end
+
+    it 'only treats the header as valid when it is the first line' do
+      write_unit(dir, 'late_header.service', header: false, body: "[Unit]\n# Deployed with puppet\n")
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource)).to be_empty
+    end
+
+    it 'ignores files whose extension is not a unit type' do
+      write_unit(dir, 'notes.txt')
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource)).to be_empty
+    end
+
+    it 'restricts purging to the configured unit_types' do
+      write_unit(dir, 'orphan.service')
+      write_unit(dir, 'orphan.timer')
+
+      resource = described_class.new(path: dir, unit_types: ['timer'])
+      expect(purged_paths(resource)).to contain_exactly(File.join(dir, 'orphan.timer'))
+    end
+
+    it 'does not descend into or purge directories named like units' do
+      FileUtils.mkdir(File.join(dir, 'multi-user.target.wants'))
+      Dir.mkdir(File.join(dir, 'subdir.service'))
+
+      resource = described_class.new(path: dir)
+      expect(purged_paths(resource)).to be_empty
+    end
+
+    it 'does not follow or purge symlinks' do
+      target = write_unit(dir, 'orphan.service')
+      File.symlink(target, File.join(dir, 'link.service'))
+
+      resource = described_class.new(path: dir)
+      # The real file is purged, the symlink is left alone.
+      expect(purged_paths(resource)).to contain_exactly(target)
+    end
+
+    it 'warns and purges nothing when the path does not exist' do
+      missing = File.join(dir, 'does-not-exist')
+      resource = described_class.new(path: missing)
+
+      expect(resource).to receive(:warning).with(%r{does not exist or is not a directory})
+      expect(purged_paths(resource)).to be_empty
+    end
+  end
+
+  describe '#purged?' do
+    it 'is true after generate finds units to purge' do
+      write_unit(dir, 'orphan.service')
+      resource = described_class.new(path: dir)
+      generate_for(resource)
+      expect(resource.purged?).to be(true)
+    end
+
+    it 'is false when generate finds nothing to purge' do
+      resource = described_class.new(path: dir)
+      generate_for(resource)
+      expect(resource.purged?).to be(false)
+    end
+  end
+end

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -38,7 +38,7 @@ $_tupled_values = [
 ]
 
 -%>
-# Deployed with puppet
+# Deployed with puppet<%# DO NOT EDIT THIS HEADER! The `systemd_purge_units` type depends on it. %>
 #
 <%-
 $_unit_sections.each | $_section | {


### PR DESCRIPTION
Add a `systemd_purge_units` type, a `systemd::purge_units` wrapper, and a
`purge_units` parameter on the base class so that removing a
`systemd::manage_unit` resource from a manifest can also remove the unit
file it deployed, without users having to declare it `ensure => absent`
first.

Only files written by `systemd::manage_unit` are eligible: the type
identifies them by the `# Deployed with puppet` header on the first line
and skips anything currently managed in the catalog, hand-written files,
symlinks, and directories. By default all unit types manage_unit can
create are considered (service, timer, path, socket, mount, automount,
swap, slice); the `unit_types` parameter narrows this.

The `systemd::purge_units` wrapper wires up a `systemd::daemon_reload`
that refreshes only when something was actually purged. Hiera users can
enable the feature via `systemd::purge_units: true`, or pass an array of
paths.

Paths are normalized before comparison so a trailing slash cannot orphan
a managed file, and a missing directory warns instead of failing the run.

The type, wrapper, base-class parameter, and class tests are my own work.
Claude (Opus 4.8) reviewed the implementation and wrote the type unit
tests and the acceptance tests.

Fixes #633