### PR TITLE
fix: refresh .link files via udev and manage networkd reliably

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -22,6 +22,7 @@
 * `systemd::logind`: This class manages systemd's login manager configuration.
 * `systemd::machine_info`: This class manages systemd's machine-info file (hostnamectl)
 * `systemd::modules_loads`: Activate the modules contained in modules-loads.d
+* `systemd::network_reload`: Reloads udev so that changed `.link` files are applied
 * `systemd::networkd`: This class provides an abstract way to trigger systemd-networkd
 * `systemd::oomd`: This class manages and configures oomd.
 * `systemd::resolved`: This class provides an abstract way to trigger resolved.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@
 #   Manage the systemd network daemon
 #
 # @param networkd_ensure
-#   The state that the ``networkd`` service should be in. **Warning** Since since v260 of systemd ensuring the service is stopped may only be transient, it is very likely some socket will activate the service nearly immediatly. 
+#   The state that the ``networkd`` service should be in. **Warning** Since since v260 of systemd ensuring the service is stopped may only be transient, it is very likely some socket will activate the service nearly immediatly.
 #
 # @param networkd_package
 #   Name of the package required for systemd-networkd, if any
@@ -451,7 +451,7 @@ class systemd (
     Class['systemd::install'] -> Class['systemd::resolved']
   }
 
-  if $manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
+  if $manage_networkd {
     contain systemd::networkd
     Class['systemd::install'] -> Class['systemd::networkd']
   }

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -26,7 +26,15 @@ define systemd::network (
 ) {
   include systemd
 
-  if $restart_service and $systemd::manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
+  if $name =~ /\.link$/ {
+    # `.link` files are read by systemd-udevd, not systemd-networkd, so they are
+    # applied by reloading udev rather than restarting the networkd service.
+    include systemd::network_reload
+    $notify = $restart_service ? {
+      true    => Exec['systemd-network-link_reload'],
+      default => undef,
+    }
+  } elsif $restart_service and $systemd::manage_networkd {
     $notify = Service['systemd-networkd']
   } else {
     $notify = undef

--- a/manifests/network_reload.pp
+++ b/manifests/network_reload.pp
@@ -1,0 +1,24 @@
+# @api private
+#
+# @summary Reloads udev so that changed `.link` files are applied
+#
+# `.link` files in the systemd-networkd directory are read by systemd-udevd,
+# not by systemd-networkd. They are applied by reloading udev and retriggering
+# the net subsystem, so `systemd::network` notifies this exec for `.link` files
+# instead of restarting systemd-networkd.
+class systemd::network_reload {
+  assert_private()
+  include systemd
+
+  exec { 'systemd-network-link_reload':
+    command     => 'udevadm control --reload && udevadm trigger --subsystem-match=net',
+    refreshonly => true,
+    path        => $facts['path'],
+  }
+
+  # Link-layer changes (interface naming, MTU, ...) must settle before
+  # systemd-networkd reconfigures the interfaces that match on them.
+  if $systemd::manage_networkd {
+    Exec['systemd-network-link_reload'] -> Service['systemd-networkd']
+  }
+}

--- a/spec/defines/network_spec.rb
+++ b/spec/defines/network_spec.rb
@@ -64,6 +64,26 @@ describe 'systemd::network' do
           it { is_expected.to create_file("/etc/systemd/network/#{title}").that_notifies('Service[systemd-networkd]') }
         end
 
+        context 'with a .link file' do
+          let(:title) { 'eth0.link' }
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.not_to create_file("/etc/systemd/network/#{title}").that_notifies('Service[systemd-networkd]') }
+
+          it { is_expected.to create_file("/etc/systemd/network/#{title}").that_notifies('Exec[systemd-network-link_reload]') }
+
+          it {
+            expect(subject).to create_exec('systemd-network-link_reload').with(
+              command: 'udevadm control --reload && udevadm trigger --subsystem-match=net',
+              refreshonly: true,
+            )
+          }
+
+          # link-layer changes must settle before networkd reconfigures
+          it { is_expected.to create_exec('systemd-network-link_reload').that_comes_before('Service[systemd-networkd]') }
+        end
+
         context 'without content and without source' do
           let :params do
             {}


### PR DESCRIPTION
#### Pull Request (PR) description
.link files in /etc/systemd/network are read by systemd-udevd, not
systemd-networkd, so notifying the networkd service never re-applied
changed .link files. Route them to a new udev reload exec
(udevadm control --reload && udevadm trigger --subsystem-match=net)
instead.

Also drop the systemd_internal_services fact guard on manage_networkd
(incorporates #596): networkd is an external package managed by this
module, so the fact isn't populated until a second Puppet run, leaving
the service unmanaged on the first run.
