### PR TITLE
fix: don't force default_target to running state

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -420,11 +420,6 @@ class systemd (
 
   if $default_target {
     $target = stdlib::shell_escape($default_target)
-    service { $target:
-      ensure => 'running',
-      enable => true,
-    }
-
     exec { "systemctl set-default ${target}":
       command => "systemctl set-default ${target}",
       unless  => "test $(systemctl get-default) = ${target}",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -393,7 +393,7 @@ describe 'systemd' do
 
           it {
             is_expected.to contain_exec('systemctl set-default example.target')
-            is_expected.to contain_service('example.target').with_enable(true).with_ensure('running')
+            is_expected.not_to contain_service('example.target')
           }
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
When `default_target` was set, the class declared a
`service { $target: ensure => 'running' }` alongside the
`systemctl set-default` exec. The service resource makes Puppet run
`systemctl start <target>`, which blocks until systemd reaches that
target. On hosts where Puppet runs during early boot (e.g. GCP
instances that start before multi-user.target is reached), this hangs
the entire run until the configtimeout fires (up to an hour).

Setting the default boot target is the parameter's purpose and is
handled idempotently by the `set-default` exec; systemd reaches the
default target on its own during boot. Remove the service resource so
Puppet no longer forces a target transition mid-converge.

#### This Pull Request (PR) fixes the following issues
Fixes #514
